### PR TITLE
Fix missing column for lastSelected in Session model

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -139,6 +139,11 @@ const Session = sequelize.define('Session', {
   type: {
     type: DataTypes.STRING,
     allowNull: false
+  },
+  lastSelected: {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   }
 }, {
   timestamps: true


### PR DESCRIPTION
## Summary
- add a `lastSelected` boolean field to the `Session` model

This field is required by the preload API to mark the last selected session but was missing in the Sequelize schema.

## Testing
- `npm run build-main` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c45ba2cc08324a389d5a7882421b8