### PR TITLE
Add car import/export

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import './Home.css';
 import { useNavigate } from 'react-router-dom';
 import { useCar } from '../context/CarContext';
@@ -6,6 +6,7 @@ import { useCar } from '../context/CarContext';
 const Home = () => {
   const { cars, selectedCar, setSelectedCar, loadCars } = useCar();
   const [parts, setParts] = useState([]);
+  const fileInputRef = useRef(null);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -52,6 +53,33 @@ const Home = () => {
     }
   };
 
+  const handleExportCar = async () => {
+    if (!selectedCar) return;
+    try {
+      const filePath = await window.api.exportCarData(selectedCar);
+      alert(`Car exported to ${filePath}`);
+    } catch (error) {
+      console.error('Error exporting car:', error);
+    }
+  };
+
+  const handleImportButton = () => {
+    fileInputRef.current.click();
+  };
+
+  const handleFileChange = async (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      try {
+        await window.api.importCarData(file.path);
+        loadCars();
+        alert('Car imported successfully');
+      } catch (error) {
+        console.error('Error importing car:', error);
+      }
+    }
+  };
+
   return (
     <div className="home-grid">
       <div className="grid-box">
@@ -63,17 +91,26 @@ const Home = () => {
           </div>
         ) : (
           <div>
-            <select value={selectedCar || ''} onChange={handleCarChange}>
-              <option value="">Select a car</option>
-              {cars.map((car) => (
-                <option key={car.id} value={car.id}>
-                  {car.name}
-                </option>
-              ))}
-            </select>
-            <button onClick={handleCreateCar}>Add another car</button>
-          </div>
-        )}
+          <select value={selectedCar || ''} onChange={handleCarChange}>
+            <option value="">Select a car</option>
+            {cars.map((car) => (
+              <option key={car.id} value={car.id}>
+                {car.name}
+              </option>
+            ))}
+          </select>
+          <button onClick={handleCreateCar}>Add another car</button>
+          <button onClick={handleExportCar} disabled={!selectedCar}>Export Car</button>
+          <button onClick={handleImportButton}>Import Car</button>
+          <input
+            type="file"
+            ref={fileInputRef}
+            style={{ display: 'none' }}
+            accept=".json"
+            onChange={handleFileChange}
+          />
+        </div>
+      )}
       </div>
       <div className="grid-box">
         <h2>Parts List</h2>

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,5 +1,7 @@
 const { contextBridge, ipcRenderer } = require('electron');
 const { Sequelize, Op, Car, Track, Part, Event, Session, PartsValues, SessionPartsValues, PreSessionNotes, PostSessionNotes } = require('./database');
+const fs = require('fs');
+const path = require('path');
 
 contextBridge.exposeInMainWorld('api', {
   getCars: async () => {
@@ -294,6 +296,102 @@ contextBridge.exposeInMainWorld('api', {
       await SessionPartsValues.destroy({ where: { sessionId } });
     } catch (error) {
       console.error('Error deleting session parts values:', error);
+    }
+  },
+  exportCarData: async (carId) => {
+    try {
+      const car = await Car.findByPk(carId, {
+        include: [
+          { model: Part, include: [PartsValues] },
+          {
+            model: Event,
+            include: [
+              { model: Track },
+              {
+                model: Session,
+                as: 'Sessions',
+                include: [SessionPartsValues, PreSessionNotes, PostSessionNotes]
+              }
+            ]
+          }
+        ]
+      });
+      if (!car) return null;
+      const exportsDir = path.join(__dirname, 'exports');
+      if (!fs.existsSync(exportsDir)) {
+        fs.mkdirSync(exportsDir);
+      }
+      const filePath = path.join(
+        exportsDir,
+        `car_${car.name.replace(/\s+/g, '_')}_${car.id}.json`
+      );
+      fs.writeFileSync(filePath, JSON.stringify(car.toJSON(), null, 2));
+      return filePath;
+    } catch (error) {
+      console.error('Error exporting car data:', error);
+      throw error;
+    }
+  },
+  importCarData: async (filePath) => {
+    try {
+      const data = JSON.parse(fs.readFileSync(filePath));
+      const newCar = await Car.create({ name: data.name });
+
+      const partIdMap = {};
+      if (data.Parts) {
+        for (const part of data.Parts) {
+          const { id, PartsValues: pv = [], ...partData } = part;
+          const newPart = await Part.create({ ...partData, carId: newCar.id });
+          partIdMap[id] = newPart.id;
+          if (pv.length > 0) {
+            await PartsValues.create({ partId: newPart.id, value: pv[0].value });
+          }
+        }
+      }
+
+      if (data.Events) {
+        for (const event of data.Events) {
+          let trackId = 1;
+          if (event.Track) {
+            let track = await Track.findOne({ where: { name: event.Track.name } });
+            if (!track) {
+              track = await Track.create({ name: event.Track.name });
+            }
+            trackId = track.id;
+          }
+          const newEvent = await Event.create({
+            name: event.name,
+            date: event.date,
+            trackId,
+            carId: newCar.id
+          });
+          for (const session of event.Sessions || []) {
+            const { SessionPartsValues: spv = [], PreSessionNotes: pre = [], PostSessionNotes: post = [], ...sessData } = session;
+            const newSession = await Session.create({ ...sessData, eventId: newEvent.id });
+
+            if (spv.length > 0) {
+              const values = {};
+              for (const [oldId, val] of Object.entries(spv[0].values || {})) {
+                if (partIdMap[oldId]) values[partIdMap[oldId]] = val;
+              }
+              await SessionPartsValues.create({ sessionId: newSession.id, values });
+            }
+
+            if (pre.length > 0) {
+              await PreSessionNotes.create({ sessionId: newSession.id, notes: pre[0].notes });
+            }
+
+            if (post.length > 0) {
+              await PostSessionNotes.create({ sessionId: newSession.id, notes: post[0].notes });
+            }
+          }
+        }
+      }
+
+      return newCar.toJSON();
+    } catch (error) {
+      console.error('Error importing car data:', error);
+      throw error;
     }
   }
 });


### PR DESCRIPTION
## Summary
- enable exporting car data to JSON files and importing it later
- add export/import buttons on the home page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c48a830648324a28f508cf42c572a