### PR TITLE
Fix export path

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -317,9 +317,10 @@ contextBridge.exposeInMainWorld('api', {
         ]
       });
       if (!car) return null;
-      const exportsDir = path.join(__dirname, 'exports');
+      const homeDir = require('os').homedir();
+      const exportsDir = path.join(homeDir, 'n20-trackside', 'exports');
       if (!fs.existsSync(exportsDir)) {
-        fs.mkdirSync(exportsDir);
+        fs.mkdirSync(exportsDir, { recursive: true });
       }
       const filePath = path.join(
         exportsDir,


### PR DESCRIPTION
## Summary
- save exported cars to a directory in the user's home folder

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c551d4ae08324a1fad4b7fb80c240