### PR TITLE
Fix export button to show folder

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, dialog } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog, shell } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const {
@@ -53,6 +53,7 @@ ipcMain.handle('export-car-data', async (event, carId) => {
             {
               model: Session,
               as: 'Sessions',
+              attributes: { exclude: ['lastSelected'] },
               include: [SessionPartsValues, PreSessionNotes, PostSessionNotes]
             }
           ]
@@ -72,6 +73,8 @@ ipcMain.handle('export-car-data', async (event, carId) => {
     }
 
     fs.writeFileSync(filePath, JSON.stringify(car.toJSON(), null, 2));
+    // Open the exported file in the user's file explorer
+    shell.showItemInFolder(filePath);
     return filePath;
   } catch (error) {
     console.error('Error exporting car data:', error);


### PR DESCRIPTION
## Summary
- show exported file in system file explorer
- avoid exporting query failure when `lastSelected` column is missing

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c6ebc1a288324a08376acfd826e27