### PR TITLE
Improve garage page UX

### DIFF
--- a/src/pages/Garage.css
+++ b/src/pages/Garage.css
@@ -107,3 +107,27 @@ button:hover {
   bottom: 0;
   background-color: rgba(0, 0, 0, 0.75);
 }
+
+.event-group {
+  background-color: #f9f9f9;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  border-radius: 4px;
+}
+
+.tip {
+  font-size: 0.85rem;
+  color: #555;
+  margin-bottom: 0.5rem;
+}
+
+.editing-input {
+  width: 100%;
+  font-size: inherit;
+  font-weight: inherit;
+  border: 1px solid #007bff;
+  background-color: #f0f8ff;
+  border-radius: 4px;
+  padding: 0.25rem;
+  box-sizing: border-box;
+}

--- a/src/pages/Garage.js
+++ b/src/pages/Garage.js
@@ -351,9 +351,10 @@ const Garage = () => {
     <div className="garage">
       <div className="left-column">
         <h2>Garage Mode</h2>
+        <p className="tip">Right click a session to delete it.</p>
         {events.length > 0 ? (
           events.map((event, index) => (
-            <div key={index}>
+            <div key={index} className="event-group">
               {editingEventId === event.id ? (
                 <input
                   type="text"
@@ -361,6 +362,7 @@ const Garage = () => {
                   onChange={handleEditingNameChange}
                   onBlur={handleEditingNameBlur}
                   autoFocus
+                  className="editing-input"
                 />
               ) : (
                 <h3
@@ -388,6 +390,7 @@ const Garage = () => {
                             onChange={handleEditingNameChange}
                             onBlur={handleEditingNameBlur}
                             autoFocus
+                            className="editing-input"
                           />
                         ) : (
                           session.name
@@ -413,10 +416,12 @@ const Garage = () => {
             onChange={handleTitleChange}
             onBlur={handleTitleBlur}
             autoFocus
+            className="editing-input"
           />
         ) : (
           <h2 onDoubleClick={handleTitleDoubleClick}>{sessionTitle}</h2>
         )}
+        <p className="tip">Double click the title to edit.</p>
         <button onClick={handleSubmit} disabled={parts.length === 0}>Submit</button>
         <PartsGrid
           gridLayout={gridLayout}


### PR DESCRIPTION
## Summary
- style editing inputs to match titles
- highlight events when expanded
- provide tips for deleting and editing names

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c77e6dd3c8324afee76d6c17caebc