### PR TITLE
Adjust editing inputs to mimic headers

### DIFF
--- a/src/pages/Garage.css
+++ b/src/pages/Garage.css
@@ -116,18 +116,31 @@ button:hover {
 }
 
 .editing-input {
-  width: auto;
-  font-size: inherit;
-  font-weight: inherit;
+  display: block;
+  width: 100%;
+  font: inherit;
+  color: inherit;
   text-align: inherit;
   background: transparent;
   border: none;
   border-bottom: 1px solid currentColor;
   padding: 0;
   margin: 0;
+  box-sizing: border-box;
 }
 
 .editing-input:focus {
   outline: none;
   border-bottom: 1px solid currentColor;
+}
+
+.event-group > .editing-input {
+  font-size: 1.17em;
+  font-weight: bold;
+}
+
+.right-column > .editing-input {
+  font-size: 1.5em;
+  font-weight: bold;
+  text-align: center;
 }

--- a/src/pages/Garage.css
+++ b/src/pages/Garage.css
@@ -116,12 +116,18 @@ button:hover {
 }
 
 .editing-input {
-  width: 100%;
+  width: auto;
   font-size: inherit;
   font-weight: inherit;
-  border: 1px solid #007bff;
-  background-color: #f0f8ff;
-  border-radius: 4px;
-  padding: 0.25rem;
-  box-sizing: border-box;
+  text-align: inherit;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid currentColor;
+  padding: 0;
+  margin: 0;
+}
+
+.editing-input:focus {
+  outline: none;
+  border-bottom: 1px solid currentColor;
 }


### PR DESCRIPTION
## Summary
- simplify styling for Garage page editing inputs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c7cc562c08324aa3132fcf1392a9f