### PR TITLE
Enhance search visibility on trackside & garage pages

### DIFF
--- a/src/components/PartsGrid.js
+++ b/src/components/PartsGrid.js
@@ -14,37 +14,49 @@ const PartsGrid = ({
   showAll,
   searchTerm,
 }) => {
+  const filterParts = (parts) =>
+    parts.filter(
+      (part) =>
+        showAll ||
+        part.name.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+
   return (
     <div className="parts-grid">
       {gridLayout.map((row, rowIndex) => (
         <div key={rowIndex} className="grid-row">
           {row.map((location) => {
-            const hasParts =
-              groupedParts[location] &&
-              Object.values(groupedParts[location]).some(
-                (arr) => Array.isArray(arr) && arr.length > 0
-              );
+            const locationParts = groupedParts[location] || {};
+            const hasParts = Object.values(locationParts).some(
+              (arr) => Array.isArray(arr) && arr.length > 0
+            );
 
             if (!hasParts) {
+              return <div key={location} className="grid-cell placeholder" />;
+            }
+
+            // Determine if any parts in this location match the current search
+            const hasVisibleParts = Object.keys(locationParts).some((sub) =>
+              filterParts(locationParts[sub] || []).length > 0
+            );
+
+            if (!hasVisibleParts && !showAll && searchTerm) {
               return <div key={location} className="grid-cell placeholder" />;
             }
 
             return (
               <div key={location} className="grid-cell">
                 <h3>{location}</h3>
-                {Object.keys(groupedParts[location] || {}).map((subheading) => (
-                  <div key={subheading}>
-                    <h4>{subheading}</h4>
-                    <ul>
-                      {(groupedParts[location][subheading] || [])
-                        .filter(
-                          (part) =>
-                            showAll ||
-                            part.name
-                              .toLowerCase()
-                              .includes(searchTerm.toLowerCase())
-                        )
-                        .map((part) => (
+                {Object.keys(locationParts).map((subheading) => {
+                  const filtered = filterParts(locationParts[subheading] || []);
+                  if (filtered.length === 0 && !showAll && searchTerm) {
+                    return null;
+                  }
+                  return (
+                    <div key={subheading}>
+                      <h4>{subheading}</h4>
+                      <ul>
+                        {filtered.map((part) => (
                           <li key={part.id}>
                             {part.name}
                             {part.entryType === 'text' && (
@@ -58,9 +70,7 @@ const PartsGrid = ({
                             )}
                             {part.entryType === 'number' && (
                               <div className="number-input">
-                                <button
-                                  onClick={() => handleDecrement(part.id)}
-                                >
+                                <button onClick={() => handleDecrement(part.id)}>
                                   -
                                 </button>
                                 <input
@@ -70,25 +80,22 @@ const PartsGrid = ({
                                     handleChange(part.id, Number(e.target.value))
                                   }
                                 />
-                                <button
-                                  onClick={() => handleIncrement(part.id)}
-                                >
+                                <button onClick={() => handleIncrement(part.id)}>
                                   +
                                 </button>
                               </div>
                             )}
                             {part.entryType === 'table' && (
-                              <button
-                                onClick={() => handleTableLinkClick(part)}
-                              >
+                              <button onClick={() => handleTableLinkClick(part)}>
                                 Table
                               </button>
                             )}
                           </li>
                         ))}
-                    </ul>
-                  </div>
-                ))}
+                      </ul>
+                    </div>
+                  );
+                })}
               </div>
             );
           })}

--- a/src/pages/Garage.css
+++ b/src/pages/Garage.css
@@ -125,3 +125,22 @@ button:hover {
   padding: 0.25rem;
   box-sizing: border-box;
 }
+
+.search-controls {
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.search-controls input {
+  flex: 1;
+  margin-right: 10px;
+}
+
+.search-controls button {
+  margin-left: 5px;
+}
+
+.search-controls button.active {
+  font-weight: bold;
+}

--- a/src/pages/Garage.js
+++ b/src/pages/Garage.js
@@ -40,6 +40,8 @@ const Garage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalCallback, setModalCallback] = useState(null);
   const navigate = useNavigate();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [showAll, setShowAll] = useState(false);
 
   useEffect(() => {
     if (carId) {
@@ -347,6 +349,14 @@ const Garage = () => {
     }
   };
 
+  const handleShowAll = () => {
+    setShowAll(true);
+  };
+
+  const handleHideAll = () => {
+    setShowAll(false);
+  };
+
   return (
     <div className="garage">
       <div className="left-column">
@@ -423,6 +433,26 @@ const Garage = () => {
         )}
         <p className="tip">Double click the title to edit.</p>
         <button onClick={handleSubmit} disabled={parts.length === 0}>Submit</button>
+        <div className="search-controls">
+          <input
+            type="text"
+            placeholder="Search Parts"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+          />
+          <button
+            className={showAll ? 'active' : ''}
+            onClick={handleShowAll}
+          >
+            Show All
+          </button>
+          <button
+            className={!showAll ? 'active' : ''}
+            onClick={handleHideAll}
+          >
+            Hide All
+          </button>
+        </div>
         <PartsGrid
           gridLayout={gridLayout}
           groupedParts={groupedParts}
@@ -431,8 +461,8 @@ const Garage = () => {
           handleIncrement={handleIncrement}
           handleDecrement={handleDecrement}
           handleTableLinkClick={handleTableLinkClick}
-          showAll={true}
-          searchTerm={''}
+          showAll={showAll}
+          searchTerm={searchTerm}
         />
       </div>
       {showTableLightbox && (


### PR DESCRIPTION
## Summary
- hide grid cells without matching parts by improving `PartsGrid`
- add parts search bar to the garage page
- style the new search bar for the garage page

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c7f977d6c8324a438c5537ba2b895