### PR TITLE
Improve trackside notes layout

### DIFF
--- a/src/pages/Trackside.css
+++ b/src/pages/Trackside.css
@@ -20,6 +20,16 @@
   padding-left: 20px;
 }
 
+.notes-columns {
+  display: flex;
+  gap: 20px;
+}
+
+.notes-columns .box {
+  width: auto;
+  flex: 1;
+}
+
 ul {
   list-style-type: none;
   padding: 0;

--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -434,11 +434,17 @@ const Trackside = () => {
             <button onClick={handleEndEvent}>End Event</button>
           </div>
           <div className="right-column">
-            <div className="box">
-              <h2>Pre-Session Notes</h2>
-              {renderNotesForm(preSessionNotes, setPreSessionNotes)}
+            <div className="notes-columns">
+              <div className="box pre-notes">
+                <h2>Pre-Session Notes</h2>
+                {renderNotesForm(preSessionNotes, setPreSessionNotes)}
+              </div>
+              <div className="box post-notes">
+                <h2>Post-Session Notes</h2>
+                {renderNotesForm(postSessionNotes, setPostSessionNotes)}
+              </div>
             </div>
-            <div className="box">
+            <div className="box setup-box">
               <h2>Setup</h2>
               <div className="search-controls">
                 <input
@@ -471,10 +477,6 @@ const Trackside = () => {
                 showAll={showAll}
                 searchTerm={searchTerm}
               />
-            </div>
-            <div className="box">
-              <h2>Post-Session Notes</h2>
-              {renderNotesForm(postSessionNotes, setPostSessionNotes)}
             </div>
             <button className="save-notes" onClick={handleSetupSubmit}>Save Notes</button>
           </div>


### PR DESCRIPTION
## Summary
- make pre/post session notes display side by side
- keep setup section full width under notes

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c7fe310308324b724a1e3a8a3c3dc