### PR TITLE
Add trackside wizard on homepage

### DIFF
--- a/src/components/TracksideWidget.css
+++ b/src/components/TracksideWidget.css
@@ -1,0 +1,35 @@
+.trackside-widget ul {
+  list-style-type: none;
+  padding: 0;
+}
+
+.trackside-widget li {
+  padding: 8px;
+  cursor: pointer;
+}
+
+.trackside-widget li.selected {
+  color: red;
+  font-weight: bold;
+}
+
+.trackside-widget .create-event {
+  margin-top: 20px;
+}
+
+.trackside-widget .create-event form {
+  display: flex;
+  flex-direction: column;
+}
+
+.trackside-widget .create-event label {
+  margin-bottom: 10px;
+}
+
+.trackside-widget .create-event input {
+  margin-bottom: 5px;
+}
+
+.trackside-widget.expand {
+  grid-row: span 2;
+}

--- a/src/components/TracksideWidget.js
+++ b/src/components/TracksideWidget.js
@@ -1,0 +1,246 @@
+import React, { useState, useEffect } from 'react';
+import { useCar } from '../context/CarContext';
+import { useEvent } from '../context/EventContext';
+import { useNavigate } from 'react-router-dom';
+import Modal from 'react-modal';
+import { Menu, Item, contextMenu } from 'react-contexify';
+import 'react-contexify/dist/ReactContexify.css';
+import './TracksideWidget.css';
+
+Modal.setAppElement('#root');
+
+const TracksideWidget = () => {
+  const { selectedCar: carId } = useCar();
+  const { setCurrentEvent } = useEvent();
+  const [events, setEvents] = useState([]);
+  const [tracks, setTracks] = useState([]);
+  const [selectedTrack, setSelectedTrack] = useState('');
+  const [eventName, setEventName] = useState('');
+  const [eventDate, setEventDate] = useState(new Date().toISOString().split('T')[0]);
+  const [sessions, setSessions] = useState(['Practice', 'Heat', 'Feature']);
+  const [newSessionName, setNewSessionName] = useState('');
+  const [selectedSessions, setSelectedSessions] = useState(['Practice', 'Heat', 'Feature']);
+  const [showForm, setShowForm] = useState(false);
+  const [showCustomSessions, setShowCustomSessions] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalCallback, setModalCallback] = useState(null);
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (carId) {
+      loadEvents();
+      loadTracks();
+    }
+  }, [carId]);
+
+  const loadEvents = async () => {
+    try {
+      const fetchedEvents = await window.api.getEventsWithSessions();
+      const filteredEvents = fetchedEvents.filter(event => event.carId == carId && event.trackId !== 1);
+      setEvents(filteredEvents);
+    } catch (error) {
+      console.error('Error loading events:', error);
+    }
+  };
+
+  const loadTracks = async () => {
+    try {
+      const fetchedTracks = await window.api.getTracks();
+      const filteredTracks = fetchedTracks.filter(track => track.id !== 1);
+      setTracks(filteredTracks);
+    } catch (error) {
+      console.error('Error loading tracks:', error);
+    }
+  };
+
+  const handleTrackChange = (e) => {
+    const trackName = e.target.value;
+    setSelectedTrack(trackName);
+    setEventName(`Racing at ${trackName}`);
+  };
+
+  const handleEventNameChange = (e) => {
+    setEventName(e.target.value);
+  };
+
+  const handleAddSession = () => {
+    if (newSessionName.trim()) {
+      setSessions([...sessions, { name: newSessionName.trim() }]);
+      setNewSessionName('');
+    }
+  };
+
+  const handleSessionChange = (session) => {
+    const name = session.name || session;
+    setSelectedSessions(prev => prev.includes(name) ? prev.filter(s => s !== name) : [...prev, name]);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    let trackId = tracks.find(track => track.name == selectedTrack)?.id;
+    if (!trackId) {
+      const newTrack = await window.api.addTrack(selectedTrack);
+      trackId = newTrack.id;
+    }
+
+    const newEvent = await window.api.addEvent(eventName, new Date(eventDate), trackId, carId);
+    const eventId = newEvent.id;
+
+    const sessionPromises = selectedSessions.map(session =>
+      window.api.addSession(eventId, new Date(), 'track', session)
+    );
+    await Promise.all(sessionPromises);
+
+    setCurrentEvent(newEvent);
+    setShowForm(false);
+    loadEvents();
+    navigate('/trackside');
+  };
+
+  const toggleForm = () => setShowForm(!showForm);
+  const toggleCustomSessions = () => setShowCustomSessions(!showCustomSessions);
+
+  const handleContextMenu = (e, item) => {
+    e.preventDefault();
+    contextMenu.show({
+      id: 'event-menu',
+      event: e,
+      props: { item }
+    });
+  };
+
+  const handleDeleteEvent = async ({ props }) => {
+    setIsModalOpen(true);
+    setModalCallback(() => async (confirm) => {
+      if (confirm) {
+        try {
+          await window.api.deleteEvent(props.item.id);
+          loadEvents();
+        } catch (error) {
+          console.error('Error deleting event:', error);
+        }
+      }
+    });
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setModalCallback(null);
+  };
+
+  const handleModalOption = async (option) => {
+    closeModal();
+    if (modalCallback) {
+      await modalCallback(option);
+    }
+  };
+
+  const handleEventClick = (event) => {
+    setCurrentEvent(event);
+    navigate('/trackside');
+  };
+
+  return (
+    <div className={`grid-box trackside-widget ${showForm ? 'expand' : ''}`}>
+      <h2>Trackside Events</h2>
+      {events.length > 0 ? (
+        <ul>
+          {events.map((event, index) => (
+            <li key={index} onClick={() => handleEventClick(event)} onContextMenu={(e) => handleContextMenu(e, event)}>
+              {event.name} - {new Date(event.date).toLocaleDateString()}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No trackside events available. Create a new event.</p>
+      )}
+      <button onClick={toggleForm}>{showForm ? 'Cancel' : 'Create New Event'}</button>
+      {showForm && (
+        <div className="create-event">
+          <h3>Create Event</h3>
+          <form onSubmit={handleSubmit}>
+            <label>
+              Track Name:
+              <input
+                type="text"
+                list="track-options"
+                value={selectedTrack}
+                onChange={handleTrackChange}
+                required
+              />
+              <datalist id="track-options">
+                {tracks.map((track, index) => (
+                  <option key={index} value={track.name} />
+                ))}
+              </datalist>
+            </label>
+            <label>
+              Event Name:
+              <input type="text" value={eventName} onChange={handleEventNameChange} />
+            </label>
+            <label>
+              Event Date:
+              <input type="date" value={eventDate} onChange={(e) => setEventDate(e.target.value)} required />
+            </label>
+            <label>
+              Sessions:
+              <div>
+                {['Practice', 'Heat', 'Feature'].map((session, index) => (
+                  <div key={index}>
+                    <input
+                      type="checkbox"
+                      id={`session-${index}`}
+                      value={session}
+                      onChange={() => handleSessionChange(session)}
+                      checked={selectedSessions.includes(session)}
+                    />
+                    <label htmlFor={`session-${index}`}>{session}</label>
+                  </div>
+                ))}
+                {sessions.slice(3).map((session, index) => (
+                  <div key={index}>
+                    <input
+                      type="checkbox"
+                      id={`session-${index + 3}`}
+                      value={session.name || session}
+                      onChange={() => handleSessionChange(session.name || session)}
+                      checked={selectedSessions.includes(session.name || session)}
+                    />
+                    <label htmlFor={`session-${index + 3}`}>{session.name || session}</label>
+                  </div>
+                ))}
+              </div>
+            </label>
+            <button type="button" onClick={toggleCustomSessions}>Add Custom Sessions</button>
+            {showCustomSessions && (
+              <div>
+                <input type="text" value={newSessionName} onChange={(e) => setNewSessionName(e.target.value)} />
+                <button type="button" onClick={handleAddSession}>+</button>
+              </div>
+            )}
+            <button type="submit">Submit</button>
+          </form>
+        </div>
+      )}
+      <Modal
+        isOpen={isModalOpen}
+        onRequestClose={closeModal}
+        contentLabel="Confirm Deletion"
+        className="modal"
+        overlayClassName="overlay"
+      >
+        <h2>Confirm Deletion</h2>
+        <p>Are you sure you want to delete this event? This action cannot be undone and will remove all associated sessions and data.</p>
+        <button onClick={() => handleModalOption(true)}>Yes</button>
+        <button onClick={() => handleModalOption(false)}>No</button>
+      </Modal>
+      <Menu id="event-menu">
+        <Item onClick={handleDeleteEvent}>Delete Event</Item>
+      </Menu>
+    </div>
+  );
+};
+
+export default TracksideWidget;

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -5,6 +5,7 @@
   grid-template-columns: repeat(3, 1fr);
   gap: 1rem;
   padding: 1rem;
+  grid-auto-rows: minmax(0, auto);
 }
 
 .grid-box {
@@ -47,4 +48,8 @@
   margin-top: 1rem;
   color: green;
   font-size: 0.9rem;
+}
+
+.grid-box.expand {
+  grid-row: span 2;
 }

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import './Home.css';
 import { useNavigate } from 'react-router-dom';
 import { useCar } from '../context/CarContext';
+import TracksideWidget from '../components/TracksideWidget';
 
 const Home = () => {
   const { cars, selectedCar, setSelectedCar, loadCars } = useCar();
@@ -141,6 +142,7 @@ const Home = () => {
           </div>
         )}
       </div>
+      <TracksideWidget />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- create `TracksideWidget` component with event list and create-event wizard
- embed `TracksideWidget` on the home page grid
- allow grid items to span two rows when the widget form is opened
- add accompanying CSS

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c80b0369c83248230536043a20764