### PR TITLE
Add trackside reopen notice

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import Navbar from './components/Navbar';
+import TracksideNotice from './components/TracksideNotice';
 import Home from './pages/Home';
 import Garage from './pages/Garage';
 import Trackside from './pages/Trackside';
@@ -16,6 +17,7 @@ const App = () => {
   return (
     <EventProvider>
     <CarProvider>
+      <TracksideNotice />
       <Navbar />
       <Routes>
         <Route path="/" element={<Home />} />

--- a/src/components/TracksideNotice.css
+++ b/src/components/TracksideNotice.css
@@ -1,0 +1,16 @@
+.trackside-notice-container {
+  width: 100%;
+  text-align: center;
+  padding: 0.5rem 0;
+}
+
+.reopen-trackside-button {
+  background: linear-gradient(90deg, #ff6b6b, #f06595);
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  font-weight: bold;
+  padding: 0.75rem 1.25rem;
+  cursor: pointer;
+  font-size: 1rem;
+}

--- a/src/components/TracksideNotice.js
+++ b/src/components/TracksideNotice.js
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useCar } from '../context/CarContext';
+import { useEvent } from '../context/EventContext';
+import './TracksideNotice.css';
+
+const TracksideNotice = () => {
+  const { selectedCar } = useCar();
+  const { setCurrentEvent } = useEvent();
+  const [todayEvent, setTodayEvent] = useState(null);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const fetchEvent = async () => {
+      if (!selectedCar) return;
+      try {
+        const event = await window.api.getTodayTracksideEvent(selectedCar);
+        setTodayEvent(event);
+      } catch (error) {
+        console.error('Error fetching today\'s event:', error);
+      }
+    };
+    fetchEvent();
+  }, [selectedCar]);
+
+  if (location.pathname === '/trackside' || !todayEvent) {
+    return null;
+  }
+
+  const handleClick = () => {
+    setCurrentEvent(todayEvent);
+    navigate('/trackside');
+  };
+
+  return (
+    <div className="trackside-notice-container">
+      <button className="reopen-trackside-button" onClick={handleClick}>
+        CLICK TO RE-OPEN TRACKSIDE FOR {todayEvent.name}
+      </button>
+    </div>
+  );
+};
+
+export default TracksideNotice;

--- a/src/preload.js
+++ b/src/preload.js
@@ -104,6 +104,27 @@ contextBridge.exposeInMainWorld('api', {
       console.error('Error fetching events from last 24 hours:', error);
     }
   },
+  getTodayTracksideEvent: async (carId) => {
+    const start = new Date();
+    start.setHours(0, 0, 0, 0);
+    const end = new Date();
+    end.setHours(23, 59, 59, 999);
+    try {
+      const event = await Event.findOne({
+        where: {
+          carId,
+          trackId: { [Op.ne]: 1 },
+          date: {
+            [Op.gte]: start,
+            [Op.lte]: end
+          }
+        }
+      });
+      return event ? event.toJSON() : null;
+    } catch (error) {
+      console.error("Error fetching today's event:", error);
+    }
+  },
   addSession: async (eventId, date, type, name) => {
     try {
       const session = await Session.create({ eventId, date, type, name });


### PR DESCRIPTION
## Summary
- add TracksideNotice component to reopen Trackside when an event exists today
- display TracksideNotice in App layout
- fetch today's trackside event in preload

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c83f23b9c8324946bea9155a2aec8