### PR TITLE
Fix grid placeholders to maintain spacing

### DIFF
--- a/src/components/PartsGrid.css
+++ b/src/components/PartsGrid.css
@@ -24,8 +24,8 @@
 
 .grid-cell.placeholder {
   visibility: hidden;
-  border: none;
-  padding: 0;
+  border: 1px solid transparent;
+  padding: 10px;
 }
   
   .number-input {


### PR DESCRIPTION
## Summary
- keep padding on `PartsGrid` placeholder cells so neighboring grid items align

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c8431937c8324a441746da7f42efe