### PR TITLE
Improve garage navigation UI

### DIFF
--- a/src/pages/Garage.css
+++ b/src/pages/Garage.css
@@ -109,6 +109,40 @@ button:hover {
   border-radius: 4px;
 }
 
+.accordion-button {
+  width: 100%;
+  text-align: left;
+  background-color: #e0e0e0;
+  border: none;
+  padding: 0.5rem 1rem;
+  position: relative;
+  cursor: pointer;
+  border-radius: 4px;
+  font-size: 1.1em;
+}
+
+.accordion-button::after {
+  content: '\25BC';
+  position: absolute;
+  right: 0.75rem;
+  transition: transform 0.2s ease;
+}
+
+.accordion-button.expanded::after {
+  transform: rotate(-180deg);
+}
+
+.session-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.25rem 0;
+}
+
+.load-btn {
+  margin-left: 0.5rem;
+}
+
 .tip {
   font-size: 0.85rem;
   color: #555;


### PR DESCRIPTION
## Summary
- highlight event headers with arrow buttons for accordion control
- show sessions in an accordion list with Load buttons
- disable single-click loading when editing names

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c8516c928832489af9467914342b9