### PR TITLE
Adjust note column widths

### DIFF
--- a/src/pages/Trackside.css
+++ b/src/pages/Trackside.css
@@ -26,8 +26,10 @@
 }
 
 .notes-columns .box {
-  width: auto;
-  flex: 1;
+  /* Each notes box should take up half of the available width while leaving
+     space for the gap between them */
+  flex: 0 0 calc(50% - 10px);
+  width: calc(50% - 10px);
 }
 
 ul {


### PR DESCRIPTION
## Summary
- tweak notes box flex properties so pre/post session notes fit side by side better

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c8872decc8324b7ed7c3cac5d2477