### PR TITLE
Improve Garage layout and highlight

### DIFF
--- a/src/pages/Garage.css
+++ b/src/pages/Garage.css
@@ -12,7 +12,8 @@
   padding: 1rem;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
+  min-height: 100vh;
 }
 
 .part-input {
@@ -105,20 +106,37 @@ button:hover {
 .event-group {
   background-color: #f9f9f9;
   padding: 0.5rem;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
   border-radius: 4px;
+  border-left: 2px solid #f0f0f0;
+  border-right: 2px solid #f0f0f0;
+  border-bottom: 2px solid #f0f0f0;
+}
+
+.event-group ul {
+  list-style: none;
+  margin: 0;
+  padding: 0 0.5rem;
+  border-left: 2px solid #f0f0f0;
+  border-right: 2px solid #f0f0f0;
+  border-bottom: 2px solid #f0f0f0;
 }
 
 .accordion-button {
   width: 100%;
   text-align: left;
-  background-color: #e0e0e0;
+  background-color: #f0f0f0;
+  color: #000;
   border: none;
   padding: 0.5rem 1rem;
   position: relative;
   cursor: pointer;
   border-radius: 4px;
   font-size: 1.1em;
+}
+
+.accordion-button.selected {
+  background-color: #d0eaff;
 }
 
 .accordion-button::after {
@@ -139,8 +157,22 @@ button:hover {
   padding: 0.25rem 0;
 }
 
+.session-item.selected {
+  background-color: #d0eaff;
+  font-weight: bold;
+}
+
 .load-btn {
   margin-left: 0.5rem;
+}
+
+.submit-button {
+  align-self: flex-start;
+  margin-top: auto;
+  font-size: 1.2em;
+  padding: 10px 20px;
+  position: sticky;
+  bottom: 20px;
 }
 
 .tip {
@@ -166,6 +198,7 @@ button:hover {
   display: flex;
   align-items: center;
   margin-bottom: 10px;
+  width: 100%;
 }
 
 .search-controls input {
@@ -193,5 +226,5 @@ button:hover {
 .right-column > .editing-input {
   font-size: 1.5em;
   font-weight: bold;
-  text-align: center;
+  text-align: left;
 }


### PR DESCRIPTION
## Summary
- tweak garage page layout and make the search controls full width
- highlight selected garage session and event
- add toast notifications for saving setups
- align title to left and pin submit button to bottom
- adjust accordion colors and spacing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c883836b8832489684159df445921