### PR TITLE
Fix alignment for part titles

### DIFF
--- a/src/components/PartsGrid.css
+++ b/src/components/PartsGrid.css
@@ -34,6 +34,7 @@
 
 .part-name {
   flex: 1;
+  text-align: left;
 }
 
 .part-controls {

--- a/src/pages/Garage.css
+++ b/src/pages/Garage.css
@@ -25,7 +25,7 @@
 
 .part-name {
   flex: 1;
-  text-align: right;
+  text-align: left;
   padding-right: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- ensure part titles align left in PartsGrid
- update Garage styles so part titles are left aligned

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c8b02310483249b1d5be558002559