### PR TITLE
Fix accordion styling

### DIFF
--- a/src/pages/Garage.css
+++ b/src/pages/Garage.css
@@ -105,17 +105,14 @@ button:hover {
 
 .event-group {
   background-color: #f9f9f9;
-  padding: 0.5rem;
   margin-bottom: 0.5rem;
   border-radius: 4px;
-  border-left: 2px solid #f0f0f0;
-  border-right: 2px solid #f0f0f0;
-  border-bottom: 2px solid #f0f0f0;
+  padding: 0;
 }
 
 .event-group ul {
   list-style: none;
-  margin: 0;
+  margin: -2px 0 0 0;
   padding: 0 0.5rem;
   border-left: 2px solid #f0f0f0;
   border-right: 2px solid #f0f0f0;
@@ -125,18 +122,19 @@ button:hover {
 .accordion-button {
   width: 100%;
   text-align: left;
-  background-color: #f0f0f0;
-  color: #000;
+  background-color: var(--primary-color);
+  color: #fff;
   border: none;
   padding: 0.5rem 1rem;
   position: relative;
   cursor: pointer;
   border-radius: 4px;
   font-size: 1.1em;
+  box-shadow: none;
 }
 
 .accordion-button.selected {
-  background-color: #d0eaff;
+  background-color: var(--primary-color);
 }
 
 .accordion-button::after {


### PR DESCRIPTION
## Summary
- remove borders around collapsed accordion
- align event borders with buttons
- restore purple styling for accordion buttons and disable box shadow

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c8bc377688324b5e7e4eee76c5df1