### PR TITLE
Update Save Notes button style and add bottom bar

### DIFF
--- a/src/pages/Garage.css
+++ b/src/pages/Garage.css
@@ -173,6 +173,30 @@ button:hover {
   bottom: 20px;
 }
 
+.save-notes {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background-color: #4caf50;
+  color: #fff;
+  padding: 1rem 1.5rem;
+  z-index: 1001;
+}
+
+.bottom-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 80px;
+  background-color: #fff;
+  z-index: 1000;
+}
+
+.bottom-space {
+  height: 80px;
+}
+
 .tip {
   font-size: 0.85rem;
   color: #555;

--- a/src/pages/Garage.js
+++ b/src/pages/Garage.js
@@ -461,6 +461,9 @@ const Garage = () => {
           showAll={showAll}
           searchTerm={searchTerm}
         />
+        <div className="bottom-space"></div>
+        <button className="save-notes" onClick={handleSubmit}>Save Notes</button>
+        <div className="bottom-bar"></div>
       </div>
       {showTableLightbox && (
         <div className="lightbox">

--- a/src/pages/Trackside.css
+++ b/src/pages/Trackside.css
@@ -119,8 +119,22 @@ ul li.selected {
   position: fixed;
   bottom: 20px;
   right: 20px;
-  background-color: var(--primary-dark);
+  background-color: #4caf50;
   color: #fff;
   padding: 1rem 1.5rem;
+  z-index: 1001;
+}
+
+.bottom-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 80px;
+  background-color: #fff;
   z-index: 1000;
+}
+
+.bottom-space {
+  height: 80px;
 }

--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -477,8 +477,10 @@ const Trackside = () => {
                 showAll={showAll}
                 searchTerm={searchTerm}
               />
+              <div className="bottom-space"></div>
             </div>
             <button className="save-notes" onClick={handleSetupSubmit}>Save Notes</button>
+            <div className="bottom-bar"></div>
           </div>
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- update save-notes styling and create white bottom bar
- place Save Notes button and bottom bar on Garage page
- add spacer below parts grid on both pages so parts remain visible

## Testing
- `npm install`
- `npm run build`
- `npm run build-main`


------
https://chatgpt.com/codex/tasks/task_e_686c8e64d0288324bc3547c9b5abbb3a