### PR TITLE
Fix garage search controls shifting

### DIFF
--- a/src/pages/Garage.css
+++ b/src/pages/Garage.css
@@ -164,14 +164,6 @@ button:hover {
   margin-left: 0.5rem;
 }
 
-.submit-button {
-  align-self: flex-start;
-  margin-top: auto;
-  font-size: 1.2em;
-  padding: 10px 20px;
-  position: sticky;
-  bottom: 20px;
-}
 
 .save-notes {
   position: fixed;

--- a/src/pages/Garage.js
+++ b/src/pages/Garage.js
@@ -429,7 +429,6 @@ const Garage = () => {
           <h2 onDoubleClick={handleTitleDoubleClick}>{sessionTitle}</h2>
         )}
         <p className="tip">Double click the title to edit.</p>
-        <button className="submit-button" onClick={handleSubmit} disabled={parts.length === 0}>Submit</button>
         <div className="search-controls">
           <input
             type="text"


### PR DESCRIPTION
## Summary
- remove outdated `submit` button from garage mode
- trim `submit-button` styles

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c912729588324b5a245605bd47b7a