### PR TITLE
Display notes templates in columns on settings page

### DIFF
--- a/src/pages/Settings.css
+++ b/src/pages/Settings.css
@@ -34,4 +34,19 @@
 
 .template-section {
   margin-bottom: 1rem;
+  background-color: var(--surface-color);
+  padding: 10px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.notes-columns {
+  display: flex;
+  gap: 20px;
+  width: calc(100% - 20px);
+}
+
+.notes-columns .template-section {
+  flex: 0 0 calc(50% - 10px);
+  width: calc(50% - 10px);
 }

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -92,8 +92,10 @@ const Settings = () => {
       <div className="right-column">
         {activeTab === 'notes' && (
           <>
-            {renderFields(preFields, 'pre')}
-            {renderFields(postFields, 'post')}
+            <div className="notes-columns">
+              {renderFields(preFields, 'pre')}
+              {renderFields(postFields, 'post')}
+            </div>
             <button onClick={handleSave}>Save Templates</button>
           </>
         )}


### PR DESCRIPTION
## Summary
- arrange pre/post notes templates in columns
- style the notes templates containers like trackside

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c9648bb0483248ded7280205e8c6e