### PR TITLE
Improve navigation consistency

### DIFF
--- a/src/pages/Garage.css
+++ b/src/pages/Garage.css
@@ -130,6 +130,7 @@ button:hover {
   cursor: pointer;
   border-radius: 4px;
   font-size: 1.1em;
+  text-transform: none;
   box-shadow: none;
 }
 

--- a/src/pages/Settings.css
+++ b/src/pages/Settings.css
@@ -35,3 +35,20 @@
 .template-section {
   margin-bottom: 1rem;
 }
+
+.nav-button {
+  width: 100%;
+  text-align: left;
+  background-color: var(--primary-color);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  font-size: 1.1em;
+  margin-bottom: 0.5rem;
+  text-transform: none;
+}
+
+.nav-button.active {
+  background-color: var(--primary-dark);
+}

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -83,7 +83,7 @@ const Settings = () => {
       <div className="left-column">
         <h2>Settings</h2>
         <button
-          className={activeTab === 'notes' ? 'active' : ''}
+          className={`nav-button ${activeTab === 'notes' ? 'active' : ''}`}
           onClick={() => setActiveTab('notes')}
         >
           Session Notes

--- a/src/pages/Trackside.css
+++ b/src/pages/Trackside.css
@@ -39,18 +39,24 @@ ul {
 }
 
 li {
-  padding: 8px;
-  cursor: pointer;
+  padding: 0;
+  margin-bottom: 0.5rem;
 }
 
-li.highlight {
-  background-color: #f0f0f0;
-  font-weight: bold;
+.session-button {
+  width: 100%;
+  text-align: left;
+  background-color: var(--primary-color);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  font-size: 1.1em;
+  text-transform: none;
 }
 
-ul li.selected {
-  color: red; /* Change the color as needed */
-  font-weight: bold; /* Optional: Makes the text bold */
+.session-button.active {
+  background-color: var(--primary-dark);
 }
 
 .box {
@@ -126,6 +132,23 @@ ul li.selected {
 }
 .save-notes:hover {
   background-color: #388e3c;
+}
+
+.end-event {
+  position: fixed;
+  bottom: 20px;
+  left: 20px;
+  background-color: #f44336;
+  color: #fff;
+  padding: 1rem 1.5rem;
+  border: none;
+  border-radius: 4px;
+  text-transform: none;
+  z-index: 1001;
+}
+
+.end-event:hover {
+  background-color: #d32f2f;
 }
 
 .bottom-bar {

--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -413,16 +413,17 @@ const Trackside = () => {
             <h2>{currentEvent.name}</h2>
             <ul>
               {sessions.map((session, index) => (
-                <li
-                  key={index}
-                  className={session.id == currentSession ? 'selected' : ''}
-                  onClick={() => handleSessionClick(session.id)}
-                >
-                  {session.name || session}
+                <li key={index}>
+                  <button
+                    className={`session-button ${session.id == currentSession ? 'active' : ''}`}
+                    onClick={() => handleSessionClick(session.id)}
+                  >
+                    {session.name || session}
+                  </button>
                 </li>
               ))}
             </ul>
-            <button onClick={handleEndEvent}>End Event</button>
+            <button className="end-event" onClick={handleEndEvent}>End Event</button>
           </div>
           <div className="right-column">
             <div className="notes-columns">


### PR DESCRIPTION
## Summary
- match navigation styles across pages
- turn off automatic capitalization for Garage accordions
- highlight active Trackside session and show end button at bottom
- style Settings nav button like other pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c973387348324ac82cca8368aad95