### PR TITLE
Adjust homepage and event button layout

### DIFF
--- a/src/components/TracksideWidget.css
+++ b/src/components/TracksideWidget.css
@@ -1,17 +1,4 @@
-.trackside-widget ul {
-  list-style-type: none;
-  padding: 0;
-}
 
-.trackside-widget li {
-  padding: 8px;
-  cursor: pointer;
-}
-
-.trackside-widget li.selected {
-  color: red;
-  font-weight: bold;
-}
 
 .trackside-widget .create-event {
   margin-top: 20px;

--- a/src/components/TracksideWidget.js
+++ b/src/components/TracksideWidget.js
@@ -145,18 +145,25 @@ const TracksideWidget = () => {
   return (
     <div className={`grid-box trackside-widget ${showForm ? 'expand' : ''}`}>
       <h2>Trackside Events</h2>
+      <button className="create-event-button" onClick={toggleForm}>{showForm ? 'Cancel' : 'Create New Event'}</button>
       {events.length > 0 ? (
-        <ul>
+        <div className="event-list">
           {events.map((event, index) => (
-            <li key={index} onClick={() => handleEventClick(event)} onContextMenu={(e) => handleContextMenu(e, event)}>
-              {event.name} - {new Date(event.date).toLocaleDateString()}
-            </li>
+            <button
+              key={index}
+              className="event-button"
+              style={{ filter: `saturate(${1 - index * 0.1})` }}
+              onClick={() => handleEventClick(event)}
+              onContextMenu={(e) => handleContextMenu(e, event)}
+            >
+              <span className="event-title">{event.name}</span>
+              <span className="event-date">{new Date(event.date).toLocaleDateString()}</span>
+            </button>
           ))}
-        </ul>
+        </div>
       ) : (
         <p>No trackside events available. Create a new event.</p>
       )}
-      <button onClick={toggleForm}>{showForm ? 'Cancel' : 'Create New Event'}</button>
       {showForm && (
         <div className="create-event">
           <h3>Create Event</h3>

--- a/src/index.css
+++ b/src/index.css
@@ -48,3 +48,30 @@ input:focus, select:focus, textarea:focus {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
   padding: 1rem;
 }
+
+.event-list {
+  list-style-type: none;
+  padding: 0;
+}
+
+.event-button {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.create-event-button {
+  width: 100%;
+  margin-bottom: 0.5rem;
+  background-color: #4caf50;
+}
+
+.event-title {
+  text-align: left;
+}
+
+.event-date {
+  margin-left: auto;
+  text-align: right;
+}

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -55,3 +55,11 @@
 .grid-box.expand {
   grid-row: span 2;
 }
+
+.car-box .parts-section {
+  margin-top: 1rem;
+}
+
+.home-grid .trackside-widget {
+  grid-column: 2;
+}

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -83,7 +83,7 @@ const Home = () => {
 
   return (
     <div className="home-grid">
-      <div className="grid-box">
+      <div className="grid-box car-box">
         <h2>Currently Selected Car</h2>
         {cars.length === 0 ? (
           <div>
@@ -120,27 +120,27 @@ const Home = () => {
             />
           </div>
         )}
-      </div>
-      <div className="grid-box">
-        <h2>Parts List</h2>
-        {selectedCar === '' ? (
-          <p>Select a car to see parts</p>
-        ) : parts.length === 0 ? (
-          <div>
-            <p>No parts! Add parts now.</p>
-            <button onClick={handleAddPart}>Add Part</button>
-          </div>
-        ) : (
-          <div>
-            <button onClick={handleAddPart}>Add Part</button>
-            <button onClick={handleModifyParts}>Modify Parts</button>
-            <ul>
-              {parts.map((part) => (
-                <li key={part.id}>{part.name}</li>
-              ))}
-            </ul>
-          </div>
-        )}
+        <div className="parts-section">
+          <h2>Parts List</h2>
+          {selectedCar === '' ? (
+            <p>Select a car to see parts</p>
+          ) : parts.length === 0 ? (
+            <div>
+              <p>No parts! Add parts now.</p>
+              <button onClick={handleAddPart}>Add Part</button>
+            </div>
+          ) : (
+            <div>
+              <button onClick={handleAddPart}>Add Part</button>
+              <button onClick={handleModifyParts}>Modify Parts</button>
+              <ul>
+                {parts.map((part) => (
+                  <li key={part.id}>{part.name}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
       </div>
       <TracksideWidget />
     </div>

--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -476,20 +476,27 @@ const Trackside = () => {
           </div>
         </div>
       ) : (
-        <>
+        <> 
           <h2>Trackside Events</h2>
+          <button className="create-event-button" onClick={toggleForm}>{showForm ? 'Cancel' : 'Create New Event'}</button>
           {events.length > 0 ? (
-            <ul>
+            <div className="event-list">
               {events.map((event, index) => (
-                <li key={index} onClick={() => setCurrentEvent(event)} onContextMenu={(e) => handleContextMenu(e, event)}>
-                  {event.name} - {new Date(event.date).toLocaleDateString()}
-                </li>
+                <button
+                  key={index}
+                  className="event-button"
+                  style={{ filter: `saturate(${1 - index * 0.1})` }}
+                  onClick={() => setCurrentEvent(event)}
+                  onContextMenu={(e) => handleContextMenu(e, event)}
+                >
+                  <span className="event-title">{event.name}</span>
+                  <span className="event-date">{new Date(event.date).toLocaleDateString()}</span>
+                </button>
               ))}
-            </ul>
+            </div>
           ) : (
             <p>No trackside events available. Create a new event.</p>
           )}
-          <button onClick={toggleForm}>{showForm ? 'Cancel' : 'Create New Event'}</button>
 
           {showForm && (
             <div className="create-event">


### PR DESCRIPTION
## Summary
- place the parts list below the selected car on the homepage
- show the Trackside events widget in the middle column
- style event lists as full‑width buttons with aging desaturation
- move the create-event button to the top and style it differently
- align event titles left and dates right on Home and Trackside wizard pages

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c9d57b8108324b21e3bd887ea1d46