### PR TITLE
Fix trackside layout padding

### DIFF
--- a/src/pages/Trackside.css
+++ b/src/pages/Trackside.css
@@ -1,7 +1,6 @@
 .trackside {
   display: flex;
   flex-direction: column;
-  padding: 1rem;
 }
 
 .dashboard {


### PR DESCRIPTION
## Summary
- remove padding from `.trackside` container so layout matches other pages

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c9e298d488324a087290e2fcc6d0d