### PR TITLE
Improve modify parts grid layout

### DIFF
--- a/src/pages/ModifyParts.css
+++ b/src/pages/ModifyParts.css
@@ -13,19 +13,7 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
 
-.parts-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 10px;
-}
-
-.grid-cell {
-  border: 1px solid #ccc;
-  padding: 10px;
-  border-radius: 4px;
-  background-color: var(--surface-color);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-}
+/* Grid styles are shared with Garage and Trackside via PartsGrid.css */
 
 .grid-cell h3 {
   margin: 0;
@@ -42,15 +30,7 @@
   padding: 0;
 }
 
-.grid-cell ul li {
-  display: flex;
-  align-items: center;
-  margin: 5px 0;
-}
-
-.grid-cell ul li button {
-  margin-left: 10px;
-}
+/* list items use the shared .part-item styles */
 
 .staged-deletions {
   background-color: red;

--- a/src/pages/ModifyParts.js
+++ b/src/pages/ModifyParts.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import './ModifyParts.css';
+import '../components/PartsGrid.css';
 import { useCar } from '../context/CarContext';
 
 const ModifyParts = () => {
@@ -165,22 +166,28 @@ const ModifyParts = () => {
           </div>
         )}
         <div className="parts-grid">
-          {displayGrid.flat().map((location) => (
-            <div key={location} className="grid-cell">
-              <h3>{location}</h3>
-              {groupedParts[location] && Object.keys(groupedParts[location]).map((subheading) => (
-                <div key={subheading}>
-                  <h4>{subheading}</h4>
-                  <ul>
-                    {groupedParts[location][subheading].map((part, index) => (
-                      <li key={part.id}>
-                        <button onClick={() => stageDeletion(part.id)}>X</button>
-                        <button onClick={() => movePart(part.id, 'up', location, subheading)}>&uarr;</button>
-                        <button onClick={() => movePart(part.id, 'down', location, subheading)}>&darr;</button>
-                        {part.name}
-                      </li>
-                    ))}
-                  </ul>
+          {displayGrid.map((row, rowIndex) => (
+            <div key={rowIndex} className="grid-row">
+              {row.map((location) => (
+                <div key={location} className="grid-cell">
+                  <h3>{location}</h3>
+                  {groupedParts[location] && Object.keys(groupedParts[location]).map((subheading) => (
+                    <div key={subheading}>
+                      <h4>{subheading}</h4>
+                      <ul>
+                        {groupedParts[location][subheading].map((part) => (
+                          <li key={part.id} className="part-item">
+                            <span className="part-name">{part.name}</span>
+                            <span className="part-controls">
+                              <button onClick={() => stageDeletion(part.id)}>X</button>
+                              <button onClick={() => movePart(part.id, 'up', location, subheading)}>&uarr;</button>
+                              <button onClick={() => movePart(part.id, 'down', location, subheading)}>&darr;</button>
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- sync Modify Parts grid layout with Garage/Trackside pages
- share PartsGrid.css for consistent styling

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c9d91097c832488e70c611c2b4316