### PR TITLE
Fix trackside widget layout and event order

### DIFF
--- a/src/components/TracksideWidget.js
+++ b/src/components/TracksideWidget.js
@@ -37,7 +37,9 @@ const TracksideWidget = () => {
   const loadEvents = async () => {
     try {
       const fetchedEvents = await window.api.getEventsWithSessions();
-      const filteredEvents = fetchedEvents.filter(event => event.carId == carId && event.trackId !== 1);
+      const filteredEvents = fetchedEvents
+        .filter(event => event.carId == carId && event.trackId !== 1)
+        .sort((a, b) => new Date(b.date) - new Date(a.date));
       setEvents(filteredEvents);
     } catch (error) {
       console.error('Error loading events:', error);

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -61,5 +61,5 @@
 }
 
 .home-grid .trackside-widget {
-  grid-column: 2;
+  grid-column: 2 / span 2;
 }


### PR DESCRIPTION
## Summary
- adjust grid columns so trackside widget spans two columns for even margins
- sort trackside events newest-first

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ca01853dc832495463d0ade2a0cfd