### PR TITLE
Add session title and update highlight color

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,7 @@
 
 :root {
   --primary-color: #6200ee;
-  --primary-dark: #3700b3;
+  --primary-dark: #0d6efd;
   --surface-color: #ffffff;
   --background-color: #fafafa;
 }

--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -81,6 +81,12 @@ const Trackside = () => {
     }
   }, [currentSession]);
 
+  useEffect(() => {
+    if (!currentSession && sessions.length > 0) {
+      setCurrentSession(sessions[0].id);
+    }
+  }, [sessions]);
+
   const loadEvents = async () => {
     try {
       const fetchedEvents = await window.api.getEventsWithSessions();
@@ -426,6 +432,7 @@ const Trackside = () => {
             <button className="end-event" onClick={handleEndEvent}>End Event</button>
           </div>
           <div className="right-column">
+            <h2>{sessions.find(s => s.id == currentSession)?.name || ''}</h2>
             <div className="notes-columns">
               <div className="box pre-notes">
                 <h2>Pre-Session Notes</h2>


### PR DESCRIPTION
## Summary
- show selected session name on Trackside page
- default to the first session after loading sessions
- change the global `--primary-dark` color for higher contrast

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ca10ae4d48324b9bb0cafb33ae99f