### PR TITLE
Fix trackside events width

### DIFF
--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -61,5 +61,5 @@
 }
 
 .home-grid .trackside-widget {
-  grid-column: 2 / span 2;
+  grid-column: 2 / span 1;
 }

--- a/src/pages/Trackside.css
+++ b/src/pages/Trackside.css
@@ -165,3 +165,8 @@ li {
 .bottom-space {
   height: 90px;
 }
+
+.trackside-events-wrapper {
+  width: 33%;
+  margin: 0 auto;
+}

--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -476,7 +476,7 @@ const Trackside = () => {
           </div>
         </div>
       ) : (
-        <> 
+        <div className="trackside-events-wrapper">
           <h2>Trackside Events</h2>
           <button className="create-event-button" onClick={toggleForm}>{showForm ? 'Cancel' : 'Create New Event'}</button>
           {events.length > 0 ? (
@@ -578,7 +578,7 @@ const Trackside = () => {
               </form>
             </div>
           )}
-        </>
+        </div>
       )}
       {showTableLightbox && (
         <div className="lightbox">


### PR DESCRIPTION
## Summary
- adjust homepage trackside events widget to span one column
- center trackside event list on Trackside page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ca23c84d48324a9644bd98509b855