### PR TITLE
Fix notes layout

### DIFF
--- a/src/pages/Trackside.css
+++ b/src/pages/Trackside.css
@@ -87,18 +87,38 @@ li {
 .notes-row {
   display: flex;
   justify-content: space-between;
+  align-items: flex-start;
   margin-bottom: 10px;
 }
 
 .notes-label {
-  flex: 1;
-  text-align: right;
+  width: 150px;
+  text-align: left;
   margin-right: 10px;
 }
 
 .notes-input {
-  flex: 2;
+  flex: 1;
   text-align: left;
+}
+
+.notes-input input,
+.notes-input textarea {
+  width: 100%;
+}
+
+.notes-row.paragraph {
+  flex-direction: column;
+}
+
+.notes-row.paragraph .notes-label {
+  width: 100%;
+  margin-right: 0;
+  margin-bottom: 5px;
+}
+
+.notes-row.paragraph .notes-input {
+  width: 100%;
 }
 
 .search-controls {

--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -368,7 +368,10 @@ const Trackside = () => {
 
   const renderNotesForm = (notes, setNotes) => {
     return notes.map((note, index) => (
-      <div className="notes-row" key={index}>
+      <div
+        className={`notes-row ${note.type === 'Paragraph' ? 'paragraph' : ''}`}
+        key={index}
+      >
         <div className="notes-label">{note.title}</div>
         <div className="notes-input">
           {note.type === 'Text' ? (


### PR DESCRIPTION
## Summary
- style notes inputs to grow to available width
- stack paragraph fields vertically

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ca2fcf218832482f355c43e56ae77