### PR TITLE
Order trackside events newest first

### DIFF
--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -90,7 +90,9 @@ const Trackside = () => {
   const loadEvents = async () => {
     try {
       const fetchedEvents = await window.api.getEventsWithSessions();
-      const filteredEvents = fetchedEvents.filter(event => event.carId == carId && event.trackId !== 1); // 1 is the ID for the "Garage" track
+      const filteredEvents = fetchedEvents
+        .filter(event => event.carId == carId && event.trackId !== 1)
+        .sort((a, b) => new Date(b.date) - new Date(a.date));
       setEvents(filteredEvents);
     } catch (error) {
       console.error('Error loading events:', error);


### PR DESCRIPTION
## Summary
- sort events on the Trackside page so the most recent event appears first

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686ca5f3e0108324a32f9ddde6bddca8