### PR TITLE
Fix trackside widget button margins

### DIFF
--- a/src/components/TracksideWidget.css
+++ b/src/components/TracksideWidget.css
@@ -1,7 +1,16 @@
 
 
+
 .trackside-widget .create-event {
   margin-top: 20px;
+}
+
+/* Remove horizontal margins inherited from .grid-box buttons so
+   event buttons align flush with the widget edges */
+.trackside-widget .event-button,
+.trackside-widget .create-event-button {
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .trackside-widget .create-event form {


### PR DESCRIPTION
## Summary
- remove left/right margins on event buttons so trackside widget aligns correctly

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ca6e449cc8324b4b3f71fcc337b83