### PR TITLE
Remove highlight for loaded setup

### DIFF
--- a/src/pages/Garage.js
+++ b/src/pages/Garage.js
@@ -369,7 +369,7 @@ const Garage = () => {
                 />
               ) : (
                 <button
-                  className={`accordion-button ${selectedEventId === event.id ? 'expanded' : ''} ${event.Sessions.some(s => s.id === currentSessionId) ? 'selected' : ''}`}
+                  className={`accordion-button ${selectedEventId === event.id ? 'expanded' : ''}`}
                   onClick={() => handleEventClick(event.id)}
                   onDoubleClick={() => handleEventDoubleClick(event)}
                   onContextMenu={(e) => handleContextMenu(e, event, 'event')}
@@ -383,7 +383,7 @@ const Garage = () => {
                     event.Sessions.map((session, index) => (
                       <li
                         key={index}
-                        className={`session-item ${currentSessionId === session.id ? 'selected' : ''}`}
+                        className="session-item"
                         onDoubleClick={() => handleSessionDoubleClick(session)}
                         onContextMenu={(e) => handleContextMenu(e, session, 'session')}
                       >
@@ -399,7 +399,11 @@ const Garage = () => {
                         ) : (
                           <>
                             <span>{session.name}</span>
-                            <button className="load-btn" onClick={() => handleLoadSession(session)}>Load</button>
+                            {currentSessionId === session.id ? (
+                              <button className="load-btn" disabled>Loaded</button>
+                            ) : (
+                              <button className="load-btn" onClick={() => handleLoadSession(session)}>Load</button>
+                            )}
                           </>
                         )}
                       </li>


### PR DESCRIPTION
## Summary
- don't highlight events or sessions for the current garage setup
- show "Loaded" disabled button instead of a Load button when a session is already loaded

## Testing
- `npm install`
- `npm run build-main`
- `npm run build-renderer`


------
https://chatgpt.com/codex/tasks/task_e_686cabaf1fd88324a824187229f617a4