### PR TITLE
Add ManageParts page with drag reorder

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import Settings from './pages/Settings';
 import CreateCar from './pages/CreateCar';
 import AddPart from './pages/AddPart';
 import ModifyParts from './pages/ModifyParts';
+import ManageParts from './pages/ManageParts';
 import { CarProvider } from './context/CarContext'; // Import the CarProvider
 import './App.css';
 import { EventProvider } from './context/EventContext';
@@ -27,6 +28,7 @@ const App = () => {
         <Route path="/create-car" element={<CreateCar />} />
         <Route path="/add-part" element={<AddPart />} />
         <Route path="/modify-parts" element={<ModifyParts />} />
+        <Route path="/manage-parts" element={<ManageParts />} />
         {/* Add more routes as needed */}
       </Routes>
     </CarProvider>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -39,7 +39,7 @@ const Home = () => {
     const selectedCarObj = cars.find(car => car.id == selectedCar);
     if (selectedCarObj) {
       console.log("Navigating to Add Part with:", { carId: selectedCarObj.id, carName: selectedCarObj.name });
-      navigate('/add-part', { state: { carId: selectedCarObj.id, carName: selectedCarObj.name } }); // Navigate to add part form
+      navigate('/manage-parts', { state: { carId: selectedCarObj.id, carName: selectedCarObj.name } });
     } else {
       console.error("Selected car not found in the fetched cars.");
     }
@@ -49,7 +49,7 @@ const Home = () => {
     const selectedCarObj = cars.find(car => car.id == selectedCar);
     if (selectedCarObj) {
       console.log("Navigating to Modify Parts with:", { carId: selectedCarObj.id, carName: selectedCarObj.name });
-      navigate('/modify-parts', { state: { carId: selectedCarObj.id, carName: selectedCarObj.name } }); // Navigate to modify parts form
+      navigate('/manage-parts', { state: { carId: selectedCarObj.id, carName: selectedCarObj.name } });
     } else {
       console.error("Selected car not found in the fetched cars.");
     }

--- a/src/pages/ManageParts.css
+++ b/src/pages/ManageParts.css
@@ -1,0 +1,19 @@
+.manage-parts {
+  display: flex;
+  gap: 20px;
+  padding: 20px;
+}
+
+.form-panel {
+  width: 320px;
+}
+
+.grid-panel {
+  flex: 1;
+  position: relative;
+}
+
+.drag-handle {
+  cursor: move;
+  margin-right: 8px;
+}

--- a/src/pages/ManageParts.js
+++ b/src/pages/ManageParts.js
@@ -1,0 +1,234 @@
+import React, { useState, useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import './ManageParts.css';
+
+const gridLayout = [
+  ["Top Left", "Top Middle", "Top Right"],
+  ["LF", "Engine", "RF"],
+  ["Driver", "Center", "Passenger"],
+  ["LR", "Differential", "RR"],
+  ["Bottom Left", "Bottom Middle", "Bottom Right"],
+];
+
+const ManageParts = () => {
+  const { state } = useLocation();
+  const { carId, carName } = state || {};
+  const [name, setName] = useState('');
+  const [unit, setUnit] = useState('');
+  const [entryType, setEntryType] = useState('text');
+  const [displayLocation, setDisplayLocation] = useState([]);
+  const [subheading, setSubheading] = useState('');
+
+  const [parts, setParts] = useState([]);
+  const [deletedParts, setDeletedParts] = useState([]);
+  const [draggedPart, setDraggedPart] = useState(null);
+  const [editingSub, setEditingSub] = useState(null);
+  const [subEditValue, setSubEditValue] = useState('');
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (carId) {
+      loadParts();
+    }
+  }, [carId]);
+
+  const loadParts = async () => {
+    const fetched = await window.api.getParts(carId);
+    const sorted = fetched.sort((a, b) => a.order - b.order);
+    setParts(sorted);
+  };
+
+  const groupParts = (partsList) => {
+    return partsList.reduce((acc, part) => {
+      const loc = part.displayLocation;
+      const sub = part.subheading?.trim() || 'Others';
+      if (!acc[loc]) acc[loc] = {};
+      if (!acc[loc][sub]) acc[loc][sub] = [];
+      acc[loc][sub].push(part);
+      return acc;
+    }, {});
+  };
+
+  const reorderParts = (updated) => {
+    const grouped = groupParts(updated);
+    Object.keys(grouped).forEach(loc => {
+      Object.keys(grouped[loc]).forEach(sub => {
+        grouped[loc][sub].sort((a,b) => a.order - b.order).forEach((p,i) => {
+          p.order = i + 1;
+        });
+      });
+    });
+    return [...updated];
+  };
+
+  const handleAddPart = () => {
+    const locs = displayLocation.length > 0 ? displayLocation : [''];
+    const newParts = locs.map(loc => ({
+      id: `new-${Date.now()}-${Math.random()}`,
+      name: displayLocation.length > 1 ? `${loc} ${name}` : name,
+      carId,
+      unit,
+      entryType,
+      displayLocation: loc,
+      subheading,
+      order: parts.length + 1,
+      isNew: true
+    }));
+    setParts(reorderParts([...parts, ...newParts]));
+    setName('');
+    setUnit('');
+    setEntryType('text');
+    setDisplayLocation([]);
+    setSubheading('');
+  };
+
+  const handleDeletePart = async (part) => {
+    if (!part.isNew) {
+      const usage = await window.api.getPartUsage(part.id) || [];
+      if (usage.length > 0) {
+        const msg = 'This part has data in the following sessions:\n' +
+          usage.map(u => `${u.event} ${new Date(u.date).toLocaleDateString()} (${u.session})`).join('\n') +
+          '\nDeleting will remove these values. Continue?';
+        if (!window.confirm(msg)) return;
+      }
+    }
+    setParts(parts.filter(p => p.id !== part.id));
+    if (!part.isNew) setDeletedParts([...deletedParts, part]);
+  };
+
+  const handleDragStart = (part) => {
+    setDraggedPart(part);
+  };
+
+  const handleDropOnPart = (targetPart) => {
+    if (!draggedPart || draggedPart.id === targetPart.id) return;
+    const updated = parts.map(p => {
+      if (p.id === draggedPart.id) return { ...p, order: targetPart.order };
+      if (p.displayLocation === targetPart.displayLocation && (p.subheading||'Others') === (targetPart.subheading||'Others')) {
+        if (p.order >= targetPart.order) return { ...p, order: p.order + 1 };
+      }
+      return p;
+    });
+    setParts(reorderParts(updated));
+    setDraggedPart(null);
+  };
+
+  const handleDropOnContainer = (location, sub) => {
+    if (!draggedPart) return;
+    const updated = parts.map(p => p.id === draggedPart.id ? { ...p, displayLocation: location, subheading: sub } : p);
+    setParts(reorderParts(updated));
+    setDraggedPart(null);
+  };
+
+  const startEditSub = (loc, sub) => {
+    setEditingSub({ loc, sub });
+    setSubEditValue(sub);
+  };
+
+  const commitEditSub = () => {
+    if (!editingSub) return;
+    const { loc, sub } = editingSub;
+    const updated = parts.map(p => (p.displayLocation === loc && (p.subheading?.trim() || 'Others') === sub) ? { ...p, subheading: subEditValue } : p);
+    setParts(updated);
+    setEditingSub(null);
+  };
+
+  const handleSave = async () => {
+    for (const part of parts) {
+      if (part.isNew) {
+        await window.api.addPart(part.name, carId, part.unit, part.entryType, part.displayLocation, part.subheading, part.order);
+      } else {
+        await window.api.updatePart(part.id, { order: part.order, subheading: part.subheading, displayLocation: part.displayLocation });
+      }
+    }
+    for (const part of deletedParts) {
+      await window.api.deletePart(part.id);
+    }
+    navigate('/');
+  };
+
+  const groupedParts = groupParts(parts);
+
+  return (
+    <div className="manage-parts">
+      <div className="form-panel">
+        <h2>Add Parts to {carName}</h2>
+        <form onSubmit={e => { e.preventDefault(); handleAddPart(); }}>
+          <label className="form-label">
+            Part Name
+            <input type="text" value={name} onChange={e => setName(e.target.value)} required />
+          </label>
+          <label className="form-label">
+            Entry Type
+            <select value={entryType} onChange={e => setEntryType(e.target.value)} required>
+              <option value="text">Text</option>
+              <option value="number">Number</option>
+              <option value="table">Table</option>
+            </select>
+          </label>
+          <label className="form-label">
+            Display Location
+            <div className="checkbox-group">
+              {['LF','RF','LR','RR'].map(loc => (
+                <div key={loc}>
+                  <input type="checkbox" value={loc} checked={displayLocation.includes(loc)} onChange={e => setDisplayLocation(prev => e.target.checked ? [...prev, loc] : prev.filter(l => l!==loc))} />
+                  <label>{loc}</label>
+                </div>
+              ))}
+            </div>
+          </label>
+          <label className="form-label">
+            Subheading
+            <input type="text" value={subheading} onChange={e => setSubheading(e.target.value)} />
+          </label>
+          <label className="form-label">
+            Unit
+            <select value={unit} onChange={e => setUnit(e.target.value)}>
+              <option value="">Select unit</option>
+              <option value="Pounds">Pounds</option>
+              <option value="Inches">Inches</option>
+              <option value="Degrees">Degrees</option>
+              <option value="Clicks">Clicks</option>
+            </select>
+          </label>
+          <button type="submit">Stage Part</button>
+        </form>
+      </div>
+      <div className="grid-panel">
+        <h2>Parts Layout</h2>
+        <div className="parts-grid">
+          {gridLayout.map((row,rowIndex) => (
+            <div key={rowIndex} className="grid-row">
+              {row.map(location => (
+                <div key={location} className="grid-cell" onDragOver={e => e.preventDefault()} onDrop={() => handleDropOnContainer(location,'Others')}>
+                  <h3>{location}</h3>
+                  {groupedParts[location] && Object.keys(groupedParts[location]).map(sub => (
+                    <div key={sub} onDragOver={e => e.preventDefault()} onDrop={() => handleDropOnContainer(location, sub)}>
+                      {editingSub && editingSub.loc===location && editingSub.sub===sub ? (
+                        <input value={subEditValue} onChange={e => setSubEditValue(e.target.value)} onBlur={commitEditSub} onKeyDown={e => e.key==='Enter' && commitEditSub()} />
+                      ) : (
+                        <h4 onDoubleClick={() => startEditSub(location, sub)}>{sub}</h4>
+                      )}
+                      <ul>
+                        {groupedParts[location][sub].sort((a,b)=>a.order-b.order).map(part => (
+                          <li key={part.id} className="part-item" draggable onDragStart={() => handleDragStart(part)} onDrop={() => handleDropOnPart(part)} onDragOver={e => e.preventDefault()}>
+                            <span className="drag-handle">::</span> {part.name}
+                            <button onClick={() => handleDeletePart(part)}>X</button>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+        <button className="save-notes" onClick={handleSave}>Save Parts</button>
+      </div>
+    </div>
+  );
+};
+
+export default ManageParts;

--- a/src/pages/ManageParts.js
+++ b/src/pages/ManageParts.js
@@ -103,13 +103,34 @@ const ManageParts = () => {
 
   const handleDropOnPart = (targetPart) => {
     if (!draggedPart || draggedPart.id === targetPart.id) return;
-    const updated = parts.map(p => {
-      if (p.id === draggedPart.id) return { ...p, order: targetPart.order };
-      if (p.displayLocation === targetPart.displayLocation && (p.subheading||'Others') === (targetPart.subheading||'Others')) {
-        if (p.order >= targetPart.order) return { ...p, order: p.order + 1 };
+
+    const sameContainer =
+      draggedPart.displayLocation === targetPart.displayLocation &&
+      (draggedPart.subheading?.trim() || 'Others') ===
+        (targetPart.subheading?.trim() || 'Others');
+
+    const updated = parts.map((p) => {
+      if (p.id === draggedPart.id) {
+        return {
+          ...p,
+          displayLocation: targetPart.displayLocation,
+          subheading: targetPart.subheading,
+          order: targetPart.order,
+        };
+      }
+
+      if (
+        p.displayLocation === targetPart.displayLocation &&
+        (p.subheading?.trim() || 'Others') ===
+          (targetPart.subheading?.trim() || 'Others')
+      ) {
+        if (p.order >= targetPart.order) {
+          return { ...p, order: p.order + 1 };
+        }
       }
       return p;
     });
+
     setParts(reorderParts(updated));
     setDraggedPart(null);
   };

--- a/src/preload.js
+++ b/src/preload.js
@@ -64,11 +64,39 @@ contextBridge.exposeInMainWorld('api', {
       console.error('Error updating part order:', error);
     }
   },
+  updatePart: async (id, updates) => {
+    try {
+      return await Part.update(updates, { where: { id } });
+    } catch (error) {
+      console.error('Error updating part:', error);
+    }
+  },
   deletePart: async (id) => {
     try {
       return await Part.destroy({ where: { id } });
     } catch (error) {
       console.error('Error deleting part:', error);
+    }
+  },
+  getPartUsage: async (partId) => {
+    try {
+      const spvs = await SessionPartsValues.findAll({ include: [{ model: Session, include: [Event] }] });
+      const usage = [];
+      for (const spv of spvs) {
+        if (spv.values && Object.prototype.hasOwnProperty.call(spv.values, partId)) {
+          if (spv.Session && spv.Session.Event) {
+            usage.push({
+              event: spv.Session.Event.name,
+              date: spv.Session.Event.date,
+              session: spv.Session.name || spv.Session.type
+            });
+          }
+        }
+      }
+      return usage;
+    } catch (error) {
+      console.error('Error fetching part usage:', error);
+      return [];
     }
   },
   addEvent: async (name, date, trackId, carId) => {


### PR DESCRIPTION
## Summary
- create ManageParts page to combine add and modify parts
- add drag-and-drop reorder and subheading editing
- warn before deleting parts with data
- expose updatePart and getPartUsage APIs
- route Home's Add/Modify buttons to new page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686da59377ec83248e5f9ee1381f4ad3