### PR TITLE
Improve yearly stats styling

### DIFF
--- a/src/components/StatsWidget.css
+++ b/src/components/StatsWidget.css
@@ -1,5 +1,6 @@
 .stats-widget .year-section {
   margin-bottom: 1rem;
+  text-align: center;
 }
 
 .stats-widget ul {
@@ -9,5 +10,20 @@
 }
 
 .stats-widget li {
-  margin: 0.2rem 0;
+  margin: 0.5rem 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.stats-widget .stat-title {
+  font-weight: bold;
+  font-size: 1.1em;
+  text-align: center;
+}
+
+.stats-widget .stat-number {
+  font-size: 1.5em;
+  font-style: italic;
+  text-align: center;
 }

--- a/src/components/StatsWidget.js
+++ b/src/components/StatsWidget.js
@@ -29,12 +29,30 @@ const StatsWidget = () => {
             <div key={year} className="year-section">
               <h3>{year}</h3>
               <ul>
-                <li>Best Feature Finish: {s.bestFeatureFinish ?? 'N/A'}</li>
-                <li>Feature Top 5s: {s.featureTopFives}</li>
-                <li>Feature Top 10s: {s.featureTopTens}</li>
-                <li>Best Improvement: {s.bestImprovement ?? 'N/A'}</li>
-                <li>Average Finish: {s.averageFinish != null ? s.averageFinish.toFixed(2) : 'N/A'}</li>
-                <li>Heat Wins: {s.heatWins}</li>
+                <li>
+                  <div className="stat-title">Best Feature Finish</div>
+                  <div className="stat-number">{s.bestFeatureFinish ?? 'N/A'}</div>
+                </li>
+                <li>
+                  <div className="stat-title">Feature Top 5s</div>
+                  <div className="stat-number">{s.featureTopFives}</div>
+                </li>
+                <li>
+                  <div className="stat-title">Feature Top 10s</div>
+                  <div className="stat-number">{s.featureTopTens}</div>
+                </li>
+                <li>
+                  <div className="stat-title">Best Improvement</div>
+                  <div className="stat-number">{s.bestImprovement ?? 'N/A'}</div>
+                </li>
+                <li>
+                  <div className="stat-title">Average Finish</div>
+                  <div className="stat-number">{s.averageFinish != null ? s.averageFinish.toFixed(2) : 'N/A'}</div>
+                </li>
+                <li>
+                  <div className="stat-title">Heat Wins</div>
+                  <div className="stat-number">{s.heatWins}</div>
+                </li>
               </ul>
             </div>
           ))


### PR DESCRIPTION
## Summary
- style yearly stats titles and numbers with central alignment
- use bigger font sizes with bold and italics for emphasis

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686da5ea8b948324866ffe76b3474e71