### PR TITLE
Add editable event info section

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -114,6 +114,32 @@ const Event = sequelize.define('Event', {
   timestamps: true
 });
 
+const EventInfo = sequelize.define('EventInfo', {
+  eventId: {
+    type: DataTypes.INTEGER,
+    references: {
+      model: Event,
+      key: 'id'
+    },
+    onDelete: 'CASCADE',
+    primaryKey: true
+  },
+  temperature: {
+    type: DataTypes.STRING,
+    allowNull: true
+  },
+  humidity: {
+    type: DataTypes.STRING,
+    allowNull: true
+  },
+  notes: {
+    type: DataTypes.TEXT,
+    allowNull: true
+  }
+}, {
+  timestamps: true
+});
+
 const Session = sequelize.define('Session', {
   id: {
     type: DataTypes.INTEGER,
@@ -298,6 +324,9 @@ PreSessionNotes.belongsTo(Session, { foreignKey: 'sessionId', onDelete: 'CASCADE
 Session.hasMany(PostSessionNotes, { foreignKey: 'sessionId', onDelete: 'CASCADE' });
 PostSessionNotes.belongsTo(Session, { foreignKey: 'sessionId', onDelete: 'CASCADE' });
 
+Event.hasOne(EventInfo, { foreignKey: 'eventId', onDelete: 'CASCADE' });
+EventInfo.belongsTo(Event, { foreignKey: 'eventId', onDelete: 'CASCADE' });
+
 // Sync database and prepopulate with the "Garage" track
 sequelize.sync({ force: false }).then(async () => {  // Do not use force: true in production as it drops and recreates the tables
   console.log("Database & tables synchronized!");
@@ -362,6 +391,7 @@ module.exports = {
   NotesTemplate,
   PreSessionNotes,
   PostSessionNotes,
+  EventInfo,
   CarTemplate,
   ChecklistNote,
   Op

--- a/src/pages/Trackside.css
+++ b/src/pages/Trackside.css
@@ -67,6 +67,19 @@ li {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
 
+.event-info label {
+  display: block;
+  margin-bottom: 5px;
+}
+
+.event-info .info-row {
+  margin-bottom: 5px;
+}
+
+.event-info button {
+  margin-right: 5px;
+}
+
 .create-event {
   margin-top: 20px;
 }

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,5 +1,5 @@
 const { contextBridge, ipcRenderer } = require('electron');
-const { Sequelize, Op, Car, Track, Part, Event, Session, PartsValues, SessionPartsValues, NotesTemplate, PreSessionNotes, PostSessionNotes, ChecklistNote, CarTemplate} = require('./database');
+const { Sequelize, Op, Car, Track, Part, Event, EventInfo, Session, PartsValues, SessionPartsValues, NotesTemplate, PreSessionNotes, PostSessionNotes, ChecklistNote, CarTemplate} = require('./database');
 const fs = require('fs');
 const path = require('path');
 
@@ -223,6 +223,33 @@ contextBridge.exposeInMainWorld('api', {
       await Event.update({ name: newName }, { where: { id: eventId } });
     } catch (error) {
       console.error('Error updating event name:', error);
+    }
+  },
+  updateEvent: async (eventId, data) => {
+    try {
+      await Event.update(data, { where: { id: eventId } });
+    } catch (error) {
+      console.error('Error updating event:', error);
+    }
+  },
+  getEventInfo: async (eventId) => {
+    try {
+      const info = await EventInfo.findOne({ where: { eventId } });
+      return info ? info.toJSON() : null;
+    } catch (error) {
+      console.error('Error fetching event info:', error);
+    }
+  },
+  updateEventInfo: async (eventId, temperature, humidity, notes) => {
+    try {
+      const existing = await EventInfo.findOne({ where: { eventId } });
+      if (existing) {
+        await EventInfo.update({ temperature, humidity, notes }, { where: { eventId } });
+      } else {
+        await EventInfo.create({ eventId, temperature, humidity, notes });
+      }
+    } catch (error) {
+      console.error('Error updating event info:', error);
     }
   },
   updateSessionName: async (sessionId, newName) => {


### PR DESCRIPTION
## Summary
- create new `EventInfo` table to hold per-event notes
- expose event info helpers in preload API
- show event details section on Trackside page with edit/save controls
- style event info box

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686da7279a988324a55681ef028c1f9a