### PR TITLE
Add draggable masonry grid for checklist notes

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -294,6 +294,11 @@ const ChecklistNote = sequelize.define('ChecklistNote', {
   content: {
     type: DataTypes.TEXT,
     allowNull: true
+  },
+  orderIndex: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    defaultValue: 0
   }
 }, {
   timestamps: true

--- a/src/pages/Checklist.css
+++ b/src/pages/Checklist.css
@@ -12,9 +12,10 @@
 .notes-list {
   list-style: none;
   padding: 0;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   gap: 1rem;
+  grid-auto-flow: dense;
 }
 
 .note-item {
@@ -33,4 +34,15 @@
 
 .note-item textarea {
   resize: vertical;
+}
+
+.note-item .dates {
+  font-size: 0.8rem;
+  color: #666;
+}
+
+@media (max-width: 600px) {
+  .notes-list {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/pages/Checklist.js
+++ b/src/pages/Checklist.js
@@ -1,5 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import { DndProvider, useDrag, useDrop } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
 import './Checklist.css';
+
+const ItemTypes = { NOTE: 'note' };
 
 const Checklist = () => {
   const [notes, setNotes] = useState([]);
@@ -43,6 +47,62 @@ const Checklist = () => {
     setNotes(notes.map(n => n.id === id ? { ...n, content: value } : n));
   };
 
+  const moveNote = (from, to) => {
+    const updated = [...notes];
+    const [moved] = updated.splice(from, 1);
+    updated.splice(to, 0, moved);
+    setNotes(updated);
+    return updated;
+  };
+
+  const handleReorderSave = async (newOrder) => {
+    await window.api.reorderChecklistNotes(newOrder.map(n => n.id));
+  };
+
+  const NoteItem = ({ note, index }) => {
+    const ref = useRef(null);
+    const [, drop] = useDrop({
+      accept: ItemTypes.NOTE,
+      hover(item) {
+        if (!ref.current || item.index === index) return;
+        moveNote(item.index, index);
+        item.index = index;
+      },
+      drop() {
+        handleReorderSave(notes);
+      }
+    });
+
+    const [{ isDragging }, drag] = useDrag({
+      type: ItemTypes.NOTE,
+      item: { id: note.id, index },
+      collect: (monitor) => ({ isDragging: monitor.isDragging() })
+    });
+
+    drag(drop(ref));
+
+    return (
+      <li ref={ref} className="note-item" style={{ opacity: isDragging ? 0.5 : 1 }}>
+        <input
+          type="text"
+          value={note.title}
+          onChange={(e) => handleTitleChange(note.id, e.target.value)}
+          onBlur={() => handleUpdate(note.id, note.title, note.content)}
+        />
+        <div className="dates">
+          Created: {new Date(note.createdAt).toLocaleDateString()}<br />
+          Modified: {new Date(note.updatedAt).toLocaleDateString()}
+        </div>
+        <textarea
+          value={note.content || ''}
+          onChange={(e) => handleContentChange(note.id, e.target.value)}
+          onBlur={() => handleUpdate(note.id, note.title, note.content)}
+        />
+        <button onClick={() => handleDelete(note.id)}>Delete</button>
+      </li>
+    );
+  };
+
   return (
     <div className="checklist">
       <h2>Checklist</h2>
@@ -61,24 +121,13 @@ const Checklist = () => {
         />
         <button type="submit">Add</button>
       </form>
-      <ul className="notes-list">
-        {notes.map(note => (
-          <li key={note.id} className="note-item">
-            <input
-              type="text"
-              value={note.title}
-              onChange={(e) => handleTitleChange(note.id, e.target.value)}
-              onBlur={() => handleUpdate(note.id, note.title, note.content)}
-            />
-            <textarea
-              value={note.content || ''}
-              onChange={(e) => handleContentChange(note.id, e.target.value)}
-              onBlur={() => handleUpdate(note.id, note.title, note.content)}
-            />
-            <button onClick={() => handleDelete(note.id)}>Delete</button>
-          </li>
-        ))}
-      </ul>
+      <DndProvider backend={HTML5Backend}>
+        <ul className="notes-list">
+          {notes.map((note, idx) => (
+            <NoteItem key={note.id} note={note} index={idx} />
+          ))}
+        </ul>
+      </DndProvider>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- show checklist items in a responsive CSS grid
- allow notes to be reordered with drag and drop
- store item order in DB using `orderIndex`
- show created and modified dates for each note

## Testing
- `npm install --ignore-scripts`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686dacfc0e0c83248191a1e042b95b4b