### PR TITLE
Fix duplicate default sessions

### DIFF
--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -265,6 +265,11 @@ const Trackside = () => {
   };
 
   const toggleForm = () => {
+    // Reset sessions when opening the form to avoid duplicates from a previous event
+    if (!showForm) {
+      setSessions([]);
+      setSelectedSessions(['Practice', 'Heat', 'Feature']);
+    }
     setShowForm(!showForm);
   };
 
@@ -279,6 +284,7 @@ const Trackside = () => {
   const handleEndEvent = () => {
     setCurrentEvent(null);
     setCurrentSession(null);
+    setSessions([]); // Clear previous sessions to avoid duplicates when creating a new event
     loadEvents(); // Refresh the events list
   };
 


### PR DESCRIPTION
## Summary
- reset sessions when starting new event forms
- clear sessions after ending an event to avoid residual checkboxes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686dacc1e5d08324a58abd7b45fe4e67