### PR TITLE
Add track photo management

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -32,6 +32,10 @@ const Track = sequelize.define('Track', {
   name: {
     type: DataTypes.STRING,
     allowNull: false
+  },
+  photo: {
+    type: DataTypes.TEXT,
+    allowNull: true
   }
 }, {
   timestamps: true
@@ -333,7 +337,7 @@ Event.hasOne(EventInfo, { foreignKey: 'eventId', onDelete: 'CASCADE' });
 EventInfo.belongsTo(Event, { foreignKey: 'eventId', onDelete: 'CASCADE' });
 
 // Sync database and prepopulate with the "Garage" track
-sequelize.sync({ force: false }).then(async () => {  // Do not use force: true in production as it drops and recreates the tables
+sequelize.sync({ alter: true }).then(async () => {  // Do not use force: true in production as it drops and recreates the tables
   console.log("Database & tables synchronized!");
 
   // Prepopulate the "Garage" track

--- a/src/pages/Settings.css
+++ b/src/pages/Settings.css
@@ -87,3 +87,27 @@
   margin-left: 0.5rem;
 }
 
+.track-list {
+  margin-bottom: 1rem;
+  background-color: var(--surface-color);
+  padding: 10px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.track-list ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.track-list li {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.track-thumb {
+  max-height: 40px;
+  margin: 0 10px;
+}
+

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -7,11 +7,17 @@ const Settings = () => {
   const [preFields, setPreFields] = useState([]);
   const [postFields, setPostFields] = useState([]);
   const [carTemplates, setCarTemplates] = useState([]);
+  const [tracks, setTracks] = useState([]);
   const { cars, loadCars } = useCar();
 
   const loadCarTemplates = async () => {
     const t = await window.api.getCarTemplates();
     setCarTemplates(t);
+  };
+
+  const loadTracks = async () => {
+    const t = await window.api.getTracks();
+    setTracks(t.filter(tr => tr.id !== 1));
   };
 
   useEffect(() => {
@@ -25,6 +31,7 @@ const Settings = () => {
     loadTemplates();
     loadCarTemplates();
     loadCars();
+    loadTracks();
   }, []);
 
   const handleAddField = (type) => {
@@ -70,6 +77,18 @@ const Settings = () => {
     loadCarTemplates();
   };
 
+  const handlePhotoUpload = (trackId, e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = async () => {
+      const dataUrl = reader.result;
+      await window.api.updateTrackPhoto(trackId, dataUrl);
+      setTracks(tracks.map(t => t.id === trackId ? { ...t, photo: dataUrl } : t));
+    };
+    reader.readAsDataURL(file);
+  };
+
   const renderFields = (fields, type) => (
     <div className="template-section">
       <h3>{type === 'pre' ? 'Pre-Session Notes' : 'Post-Session Notes'}</h3>
@@ -111,6 +130,12 @@ const Settings = () => {
         >
           Template Car
         </button>
+        <button
+          className={`nav-button ${activeTab === 'tracks' ? 'active' : ''}`}
+          onClick={() => setActiveTab('tracks')}
+        >
+          Tracks
+        </button>
       </div>
       <div className="right-column">
         {activeTab === 'notes' && (
@@ -143,6 +168,27 @@ const Settings = () => {
               </ul>
             </div>
           </>
+        )}
+        {activeTab === 'tracks' && (
+          <div className="track-list">
+            <h3>Track Photos</h3>
+            <ul>
+              {tracks.map(t => (
+                <li key={t.id}>
+                  {t.name}
+                  {t.photo && <img src={t.photo} alt={t.name} className="track-thumb" />}
+                  <button onClick={() => document.getElementById(`track-photo-${t.id}`).click()}>Upload Photo</button>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    id={`track-photo-${t.id}`}
+                    style={{ display: 'none' }}
+                    onChange={(e) => handlePhotoUpload(t.id, e)}
+                  />
+                </li>
+              ))}
+            </ul>
+          </div>
         )}
       </div>
     </div>

--- a/src/pages/Trackside.css
+++ b/src/pages/Trackside.css
@@ -73,6 +73,23 @@ li {
   margin-bottom: 5px;
 }
 
+.event-info {
+  padding: 0;
+  overflow: hidden;
+}
+
+.event-info-content {
+  padding: 10px;
+}
+
+.track-photo {
+  width: 100%;
+  max-height: 200px;
+  object-fit: cover;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
 .event-info .info-row {
   margin-bottom: 5px;
 }

--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -475,36 +475,44 @@ const Trackside = () => {
               ))}
             </ul>
             <div className="event-info box">
-              {isEditingInfo ? (
-                <>
-                  <div className="form-group">
-                    <label>Track:</label>
-                    <input type="text" list="track-options" value={editTrack} onChange={(e) => setEditTrack(e.target.value)} />
-                    <datalist id="track-options">
-                      {tracks.map((track, index) => (
-                        <option key={index} value={track.name} />
-                      ))}
-                    </datalist>
-                  </div>
-                  <div className="form-group">
-                    <label>Event Name:</label>
-                    <input type="text" value={editName} onChange={(e) => setEditName(e.target.value)} />
-                  </div>
-                  <div className="form-group">
-                    <label>Event Date:</label>
-                    <input type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} />
-                  </div>
-                  <button onClick={saveEventInfo}>💾</button>
-                  <button onClick={cancelEditInfo}>Cancel</button>
-                </>
-              ) : (
-                <>
-                  <div className="info-row"><strong>Track:</strong> {tracks.find(t => t.id === currentEvent.trackId)?.name}</div>
-                  <div className="info-row"><strong>Event:</strong> {currentEvent.name}</div>
-                  <div className="info-row"><strong>Date:</strong> {new Date(currentEvent.date).toISOString().split('T')[0]}</div>
-                  <button className="edit-info" onClick={startEditInfo}>✏️</button>
-                </>
-              )}
+              {(() => {
+                const track = tracks.find(t => t.id === currentEvent.trackId);
+                return track && track.photo ? (
+                  <img src={track.photo} alt={track.name} className="track-photo" />
+                ) : null;
+              })()}
+              <div className="event-info-content">
+                {isEditingInfo ? (
+                  <>
+                    <div className="form-group">
+                      <label>Track:</label>
+                      <input type="text" list="track-options" value={editTrack} onChange={(e) => setEditTrack(e.target.value)} />
+                      <datalist id="track-options">
+                        {tracks.map((track, index) => (
+                          <option key={index} value={track.name} />
+                        ))}
+                      </datalist>
+                    </div>
+                    <div className="form-group">
+                      <label>Event Name:</label>
+                      <input type="text" value={editName} onChange={(e) => setEditName(e.target.value)} />
+                    </div>
+                    <div className="form-group">
+                      <label>Event Date:</label>
+                      <input type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} />
+                    </div>
+                    <button onClick={saveEventInfo}>💾</button>
+                    <button onClick={cancelEditInfo}>Cancel</button>
+                  </>
+                ) : (
+                  <>
+                    <div className="info-row"><strong>Track:</strong> {tracks.find(t => t.id === currentEvent.trackId)?.name}</div>
+                    <div className="info-row"><strong>Event:</strong> {currentEvent.name}</div>
+                    <div className="info-row"><strong>Date:</strong> {new Date(currentEvent.date).toISOString().split('T')[0]}</div>
+                    <button className="edit-info" onClick={startEditInfo}>✏️</button>
+                  </>
+                )}
+              </div>
             </div>
             <div className="event-conditions box">
               <div className="form-group">

--- a/src/preload.js
+++ b/src/preload.js
@@ -295,12 +295,19 @@ contextBridge.exposeInMainWorld('api', {
       console.error('Error fetching tracks:', error);
     }
   },
-  addTrack: async (name) => {
+  addTrack: async (name, photo = null) => {
     try {
-      const track = await Track.create({ name });
+      const track = await Track.create({ name, photo });
       return track.toJSON();
     } catch (error) {
       console.error('Error adding track:', error);
+    }
+  },
+  updateTrackPhoto: async (trackId, photo) => {
+    try {
+      await Track.update({ photo }, { where: { id: trackId } });
+    } catch (error) {
+      console.error('Error updating track photo:', error);
     }
   },
   getSession: async (sessionId) => {


### PR DESCRIPTION
## Summary
- allow Track table to store photo paths
- sync DB with `alter: true`
- expose APIs for updating track photos
- display track photo on the Trackside event info box
- add track photo management tab in Settings
- style track photo sections

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686db119c70c8324839c37b50e097c6f