### PR TITLE
Update manage parts form layout and options

### DIFF
--- a/src/pages/ManageParts.css
+++ b/src/pages/ManageParts.css
@@ -8,6 +8,39 @@
   width: 320px;
 }
 
+.form-panel form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-panel label.form-label {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-panel input,
+.form-panel select {
+  padding: 0.5rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.checkbox-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.checkbox-group > div {
+  display: flex;
+  align-items: center;
+}
+
+.checkbox-group input {
+  margin-right: 0.5rem;
+}
+
 .grid-panel {
   flex: 1;
   position: relative;

--- a/src/pages/ManageParts.js
+++ b/src/pages/ManageParts.js
@@ -10,6 +10,9 @@ const gridLayout = [
   ["Bottom Left", "Bottom Middle", "Bottom Right"],
 ];
 
+// Flattened list of all locations used for the checkbox form
+const locationOptions = gridLayout.flat();
+
 const ManageParts = () => {
   const { state } = useLocation();
   const { carId, carName } = state || {};
@@ -199,9 +202,20 @@ const ManageParts = () => {
           <label className="form-label">
             Display Location
             <div className="checkbox-group">
-              {['LF','RF','LR','RR'].map(loc => (
+              {locationOptions.map(loc => (
                 <div key={loc}>
-                  <input type="checkbox" value={loc} checked={displayLocation.includes(loc)} onChange={e => setDisplayLocation(prev => e.target.checked ? [...prev, loc] : prev.filter(l => l!==loc))} />
+                  <input
+                    type="checkbox"
+                    value={loc}
+                    checked={displayLocation.includes(loc)}
+                    onChange={e =>
+                      setDisplayLocation(prev =>
+                        e.target.checked
+                          ? [...prev, loc]
+                          : prev.filter(l => l !== loc)
+                      )
+                    }
+                  />
                   <label>{loc}</label>
                 </div>
               ))}


### PR DESCRIPTION
## Summary
- improve manage parts form styling so labels stack above inputs
- offer full set of display location checkboxes

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686db222e4e483249884c06eccec9735