### PR TITLE
Fix display location alignment

### DIFF
--- a/src/pages/ManageParts.css
+++ b/src/pages/ManageParts.css
@@ -35,10 +35,11 @@
 .checkbox-group > div {
   display: flex;
   align-items: center;
+  justify-content: space-between;
 }
 
 .checkbox-group input {
-  margin-right: 0.5rem;
+  margin-left: 0.5rem;
 }
 
 .grid-panel {

--- a/src/pages/ManageParts.js
+++ b/src/pages/ManageParts.js
@@ -204,6 +204,7 @@ const ManageParts = () => {
             <div className="checkbox-group">
               {locationOptions.map(loc => (
                 <div key={loc}>
+                  <label>{loc}</label>
                   <input
                     type="checkbox"
                     value={loc}
@@ -216,7 +217,6 @@ const ManageParts = () => {
                       )
                     }
                   />
-                  <label>{loc}</label>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- left-align part display location titles
- right-align checkboxes for display location

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686db4a8e13c8324a3e0836b609aed4d