### PR TITLE
Ensure trackside event notes are per event

### DIFF
--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -77,7 +77,11 @@ const Trackside = () => {
       loadSessions(currentEvent.id);
       setShowForm(false);
       window.api.getEventInfo(currentEvent.id).then(info => {
-        if (info) setEventInfo(info);
+        if (info) {
+          setEventInfo(info);
+        } else {
+          setEventInfo({ temperature: '', humidity: '', notes: '' });
+        }
       });
     }
   }, [currentEvent]);


### PR DESCRIPTION
## Summary
- reset eventInfo when no stored record for new event

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686db51bde888324837c0eeffe6d24cb