### PR TITLE
Implement draggable session tabs

### DIFF
--- a/src/pages/Trackside.css
+++ b/src/pages/Trackside.css
@@ -235,3 +235,26 @@ li {
   width: 33%;
   margin: 0 auto;
 }
+
+.session-tabs {
+  display: flex;
+  margin-bottom: 10px;
+  border-bottom: 1px solid #ddd;
+}
+
+.session-tab {
+  padding: 0.5rem 1rem;
+  margin-right: 2px;
+  cursor: pointer;
+  background-color: #eee;
+  border: 1px solid #ddd;
+  border-bottom: none;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  user-select: none;
+}
+
+.session-tab.active {
+  background-color: var(--primary-color);
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- switch Trackside session list to draggable tabs
- persist tab ordering in `localStorage`
- hide session title to make room for the tabs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686db5f64e2c8324a98c36b4edddae02