### PR TITLE
Highlight current trackside event

### DIFF
--- a/src/components/Navbar.css
+++ b/src/components/Navbar.css
@@ -7,34 +7,32 @@
   display: flex;
   align-items: center;
 }
-  
-  .navbar-list {
-    list-style: none;
-    display: flex;
-    gap: 1rem;
-    padding: 0;
-    margin: 0;
-    margin-right: auto;
-  }
-  
-  .navbar-item {
-    display: inline;
-  }
-  
-  .navbar-item a {
-    text-decoration: none;
-    color: #333;
-    padding: 0.5rem 1rem;
-    border-radius: 4px;
-    transition: background-color 0.3s ease;
-  }
-  
-  .navbar-item a:hover {
-    background-color: #e0e0e0;
-  }
-  
-  .navbar-item a.active {
-    background-color: var(--primary-color);
-    color: white;
-  }
-  
+.navbar-list {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+  margin-right: auto;
+}
+
+.navbar-item {
+  display: inline;
+}
+
+.navbar-item a {
+  text-decoration: none;
+  color: #333;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  transition: background-color 0.3s ease;
+}
+
+.navbar-item a:hover {
+  background-color: #e0e0e0;
+}
+
+.navbar-item a.active {
+  background-color: var(--primary-color);
+  color: white;
+}

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import TracksideNotice from './TracksideNotice';
 import './Navbar.css';
 
 const Navbar = () => {
@@ -23,7 +22,6 @@ const Navbar = () => {
           <NavLink to="/settings" className={({ isActive }) => (isActive ? 'active' : '')}>Settings</NavLink>
         </li>
       </ul>
-      <TracksideNotice />
     </nav>
   );
 };

--- a/src/components/TracksideWidget.js
+++ b/src/components/TracksideWidget.js
@@ -169,24 +169,38 @@ const TracksideWidget = () => {
     navigate('/trackside');
   };
 
+  const isEventRunning = (event) => {
+    const created = new Date(event.createdAt);
+    const now = new Date();
+    const diff = Math.abs(now - created);
+    return diff <= 6 * 60 * 60 * 1000 && created.toDateString() === now.toDateString();
+  };
+
   return (
     <div className={`grid-box trackside-widget ${showForm ? 'expand' : ''}`}>
       <h2>Trackside Events</h2>
       <button className="create-event-button" onClick={toggleForm}>{showForm ? 'Cancel' : 'Create New Event'}</button>
       {events.length > 0 ? (
         <div className="event-list">
-          {events.map((event, index) => (
-            <button
-              key={index}
-              className="event-button"
-              style={{ filter: `saturate(${1 - index * 0.1})` }}
-              onClick={() => handleEventClick(event)}
-              onContextMenu={(e) => handleContextMenu(e, event)}
-            >
-              <span className="event-title">{event.name}</span>
-              <span className="event-date">{new Date(event.date).toLocaleDateString()}</span>
-            </button>
-          ))}
+          {events.map((event, index) => {
+            const track = tracks.find(t => t.id == event.trackId);
+            const running = isEventRunning(event);
+            return (
+              <button
+                key={index}
+                className={`event-button${running ? ' running' : ''}`}
+                style={{
+                  filter: `saturate(${1 - index * 0.1})`,
+                  '--track-photo': track && track.photo ? `url(${track.photo})` : 'none'
+                }}
+                onClick={() => handleEventClick(event)}
+                onContextMenu={(e) => handleContextMenu(e, event)}
+              >
+                <span className="event-title">{event.name}</span>
+                <span className="event-date">{new Date(event.date).toLocaleDateString()}</span>
+              </button>
+            );
+          })}
         </div>
       ) : (
         <p>No trackside events available. Create a new event.</p>

--- a/src/index.css
+++ b/src/index.css
@@ -59,12 +59,39 @@ input:focus, select:focus, textarea:focus {
   display: flex;
   justify-content: space-between;
   margin-bottom: 0.5rem;
+  position: relative;
+  overflow: hidden;
+  border: none;
+}
+
+.event-button::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: var(--track-photo);
+  background-size: cover;
+  background-position: center;
+  filter: grayscale(100%);
+  opacity: 0.3;
+  pointer-events: none;
+  -webkit-mask-image: linear-gradient(to right, transparent, black 20%, black 80%, transparent);
+          mask-image: linear-gradient(to right, transparent, black 20%, black 80%, transparent);
+}
+
+.event-button.running {
+  border: 2px solid orange;
 }
 
 .create-event-button {
   width: 100%;
   margin-bottom: 0.5rem;
   background-color: #4caf50;
+}
+
+.event-title,
+.event-date {
+  position: relative;
+  z-index: 1;
 }
 
 .event-title {


### PR DESCRIPTION
## Summary
- remove TracksideNotice component from navbar
- show orange border around events created within the last 6 hours
- display track photo in event buttons with grayscale and fading edges
- clean up navbar styles

## Testing
- `npm run build-main`
- `npm run build-renderer`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686db7b9c07083249649a48beb264044