### PR TITLE
Fix session tab ordering

### DIFF
--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -365,6 +365,10 @@ const Trackside = () => {
     updated.splice(index, 0, moved);
     setSessions(updated);
     setDraggedTabIndex(null);
+    if (currentEvent) {
+      const order = updated.map(s => s.id);
+      localStorage.setItem(`sessionOrder_${currentEvent.id}`, JSON.stringify(order));
+    }
   };
 
   const handleTableLightboxClose = () => {
@@ -392,8 +396,12 @@ const Trackside = () => {
       await window.api.updatePreSessionNotes(currentSession, preSessionNotes);
       await window.api.updatePostSessionNotes(currentSession, postSessionNotes);
       await window.api.updateEventInfo(currentEvent.id, eventInfo.temperature, eventInfo.humidity, eventInfo.notes);
-  
+
       // Refresh the sessions to ensure data is up-to-date but preserve current session
+      if (currentEvent && sessions.length > 0) {
+        const order = sessions.map(s => s.id);
+        localStorage.setItem(`sessionOrder_${currentEvent.id}`, JSON.stringify(order));
+      }
       await loadSessions(currentEvent.id);
       setCurrentSession(currentSession); // Ensure the selected session remains highlighted
   


### PR DESCRIPTION
## Summary
- keep session order when reordering tabs
- persist tab order before loading sessions on save

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686db839751083248be383e7fca3c5b6