### PR TITLE
Add session tab rename and create

### DIFF
--- a/src/pages/Trackside.css
+++ b/src/pages/Trackside.css
@@ -254,6 +254,16 @@ li {
   user-select: none;
 }
 
+.session-tab.add-tab {
+  font-weight: bold;
+}
+
+.session-tab input {
+  width: 100%;
+  border: none;
+  background: transparent;
+}
+
 .session-tab.active {
   background-color: var(--primary-color);
   color: #fff;


### PR DESCRIPTION
## Summary
- add editing state and context menu for sessions
- allow adding sessions via plus tab
- support renaming session names
- tweak tab CSS for add button and editing input

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686db9757d008324a978fbe36ff7fdbf