### PR TITLE
Add 'Bring Setup To Garage' on Trackside

### DIFF
--- a/src/pages/Garage.js
+++ b/src/pages/Garage.js
@@ -64,6 +64,18 @@ const Garage = () => {
       setParts(sortedParts);
 
       await initializeValues(sortedParts, partsValues);
+
+      const storedValues = localStorage.getItem('garageSetupValues');
+      if (storedValues) {
+        setValues(JSON.parse(storedValues));
+        localStorage.removeItem('garageSetupValues');
+      }
+      const storedTitle = localStorage.getItem('garageSetupTitle');
+      if (storedTitle) {
+        setSessionTitle(storedTitle);
+        localStorage.removeItem('garageSetupTitle');
+      }
+
       groupPartsByLocation(sortedParts);
     } catch (error) {
       console.error('Error loading parts:', error);

--- a/src/pages/Trackside.css
+++ b/src/pages/Trackside.css
@@ -215,6 +215,16 @@ li {
   background-color: #d32f2f;
 }
 
+.bring-garage {
+  background-color: #0d6efd;
+  color: #fff;
+  margin-bottom: 10px;
+}
+
+.bring-garage:hover {
+  background-color: #0b5ed7;
+}
+
 .bottom-bar {
   position: fixed;
   bottom: 0;

--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -354,6 +354,14 @@ const Trackside = () => {
     setShowTableLightbox(true);
   };
 
+  const handleBringSetupToGarage = () => {
+    localStorage.setItem('garageSetupValues', JSON.stringify(values));
+    if (currentEvent) {
+      localStorage.setItem('garageSetupTitle', `Setup from ${currentEvent.name}`);
+    }
+    navigate('/garage');
+  };
+
   const handleTabDragStart = (index) => {
     setDraggedTabIndex(index);
   };
@@ -590,6 +598,7 @@ const Trackside = () => {
             </div>
             <div className="box setup-box">
               <h2>Setup</h2>
+              <button className="bring-garage" onClick={handleBringSetupToGarage}>Bring Setup To Garage</button>
               <div className="search-controls">
                 <input
                   type="text"


### PR DESCRIPTION
## Summary
- add button under Setup title on trackside
- clicking button saves setup values and opens Garage page
- Garage reads stored values and session title on load
- style button in blue

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686dbb0f3dd08324855c77ecca04e28e