### PR TITLE
Fix gradient for 50% event photos

### DIFF
--- a/src/components/TracksideWidget.js
+++ b/src/components/TracksideWidget.js
@@ -129,11 +129,11 @@ const TracksideWidget = () => {
   const toggleForm = () => setShowForm(!showForm);
   const toggleCustomSessions = () => setShowCustomSessions(!showCustomSessions);
 
-  const handleContextMenu = (e, item) => {
-    e.preventDefault();
+  const handleContextMenu = (event, item) => {
+    event.preventDefault();
     contextMenu.show({
       id: 'event-menu',
-      event: e,
+      event,
       props: { item }
     });
   };

--- a/src/index.css
+++ b/src/index.css
@@ -69,13 +69,14 @@ input:focus, select:focus, textarea:focus {
   position: absolute;
   inset: 0;
   background-image: var(--track-photo);
-  background-size: cover;
+  background-size: 50% auto;
+  background-repeat: no-repeat;
   background-position: center;
   filter: grayscale(100%);
   opacity: 0.3;
   pointer-events: none;
-  -webkit-mask-image: linear-gradient(to right, transparent, black 20%, black 80%, transparent);
-          mask-image: linear-gradient(to right, transparent, black 20%, black 80%, transparent);
+  -webkit-mask-image: linear-gradient(to right, transparent, black 25%, black 75%, transparent);
+          mask-image: linear-gradient(to right, transparent, black 25%, black 75%, transparent);
 }
 
 .event-button.running {

--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -302,11 +302,11 @@ const Trackside = () => {
     loadEvents(); // Refresh the events list
   };
 
-  const handleContextMenu = (e, item) => {
-    e.preventDefault();
+  const handleContextMenu = (event, item) => {
+    event.preventDefault();
     contextMenu.show({
       id: 'event-menu',
-      event: e,
+      event,
       props: { item }
     });
   };


### PR DESCRIPTION
## Summary
- keep event button track photos at 50% width
- update mask gradient so edges fade correctly

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686dba6e38d083249e2ab032850c86e6