### PR TITLE
Fix event highlight timing

### DIFF
--- a/src/components/TracksideWidget.js
+++ b/src/components/TracksideWidget.js
@@ -170,10 +170,10 @@ const TracksideWidget = () => {
   };
 
   const isEventRunning = (event) => {
-    const created = new Date(event.createdAt);
+    const eventDate = new Date(event.date);
     const now = new Date();
-    const diff = Math.abs(now - created);
-    return diff <= 6 * 60 * 60 * 1000 && created.toDateString() === now.toDateString();
+    const diff = Math.abs(now - eventDate);
+    return diff <= 6 * 60 * 60 * 1000 && eventDate.toDateString() === now.toDateString();
   };
 
   return (


### PR DESCRIPTION
## Summary
- use `event.date` rather than `createdAt` to determine running events

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686dbe7976c88324a34783e4ac44fe23