### PR TITLE
Improve garage event selection and rename UI

### DIFF
--- a/src/pages/Garage.css
+++ b/src/pages/Garage.css
@@ -251,3 +251,15 @@ button:hover {
   font-weight: bold;
   text-align: left;
 }
+
+.event-select-list {
+  list-style: none;
+  padding: 0;
+  max-height: 200px;
+  overflow-y: auto;
+  margin-bottom: 1rem;
+}
+
+.event-select-list li {
+  margin-bottom: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- allow saving notes to any garage event via new modal
- switch rename actions from double-click to right-click
- add rename options to context menus
- style event selection list

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686dc728719c832486a12fcf07138878