### PR TITLE
Fix load setup modal width

### DIFF
--- a/src/pages/Trackside.css
+++ b/src/pages/Trackside.css
@@ -342,3 +342,7 @@ li {
 .load-section {
   margin-bottom: 1rem;
 }
+
+.load-setup-modal {
+  width: 25%;
+}

--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -912,7 +912,7 @@ const Trackside = () => {
         isOpen={showLoadModal}
         onRequestClose={() => setShowLoadModal(false)}
         contentLabel="Load Setup"
-        className="modal"
+        className="modal load-setup-modal"
         overlayClassName="overlay"
       >
         <h2>Load Setup</h2>


### PR DESCRIPTION
## Summary
- adjust 'Load Setup' modal width

## Testing
- `npm run build-main`
- `npm run build-renderer`


------
https://chatgpt.com/codex/tasks/task_e_686dc898f5cc8324b2611e6af7fc977c