### PR TITLE
Fix deletion callback execution

### DIFF
--- a/src/components/TracksideWidget.js
+++ b/src/components/TracksideWidget.js
@@ -140,7 +140,7 @@ const TracksideWidget = () => {
 
   const handleDeleteEvent = async ({ props }) => {
     setIsModalOpen(true);
-    setModalCallback(() => async (confirm) => {
+    setModalCallback(async (confirm) => {
       if (confirm) {
         try {
           await window.api.deleteEvent(props.item.id);

--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -332,7 +332,7 @@ const Trackside = () => {
   const handleDeleteEvent = async ({ props }) => {
     setModalMessage('Are you sure you want to delete this event? This action cannot be undone and will remove all associated sessions and data.');
     setIsModalOpen(true);
-    setModalCallback(() => async (confirm) => {
+    setModalCallback(async (confirm) => {
       if (confirm) {
         try {
           await window.api.deleteEvent(props.item.id);
@@ -469,7 +469,7 @@ const Trackside = () => {
   const handleDeleteSession = async ({ props }) => {
     setModalMessage('Are you sure you want to delete this session? This action cannot be undone and will remove all associated data.');
     setIsModalOpen(true);
-    setModalCallback(() => async (confirm) => {
+    setModalCallback(async (confirm) => {
       if (confirm) {
         try {
           if (currentSession === props.session.id) {


### PR DESCRIPTION
## Summary
- fix deletion callback functions by storing async callback directly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686dc80a7d548324a2f7958ea64dd653