### PR TITLE
Fix context menu event handling

### DIFF
--- a/src/components/TracksideWidget.js
+++ b/src/components/TracksideWidget.js
@@ -133,7 +133,7 @@ const TracksideWidget = () => {
     event.preventDefault();
     contextMenu.show({
       id: 'event-menu',
-      event,
+      event: event.nativeEvent || event,
       props: { item }
     });
   };

--- a/src/pages/Garage.js
+++ b/src/pages/Garage.js
@@ -278,7 +278,7 @@ const Garage = () => {
     e.preventDefault();
     contextMenu.show({
       id: type === 'event' ? 'event-menu' : 'session-menu',
-      event: e,
+      event: e.nativeEvent || e,
       props: { item }
     });
   };

--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -324,7 +324,7 @@ const Trackside = () => {
     event.preventDefault();
     contextMenu.show({
       id: 'event-menu',
-      event,
+      event: event.nativeEvent || event,
       props: { item }
     });
   };
@@ -456,7 +456,7 @@ const Trackside = () => {
     e.preventDefault();
     contextMenu.show({
       id: 'session-menu',
-      event: e,
+      event: e.nativeEvent || e,
       props: { session }
     });
   };


### PR DESCRIPTION
## Summary
- normalize event objects when opening context menus

## Testing
- `npm run build-main`
- `npm run build-renderer`


------
https://chatgpt.com/codex/tasks/task_e_686dcda106148324b2013f9bae271fcd