### PR TITLE
Fix modal callback execution check

### DIFF
--- a/src/components/TracksideWidget.js
+++ b/src/components/TracksideWidget.js
@@ -162,7 +162,7 @@ const TracksideWidget = () => {
 const handleModalOption = async (option) => {
     console.debug('Modal option selected:', option);
     const cb = modalCallback;
-    const hasCallback = Boolean(cb);
+    const hasCallback = typeof cb === 'function';
     console.debug('Has modal callback:', hasCallback);
     closeModal();
     if (hasCallback) {

--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -355,7 +355,7 @@ const Trackside = () => {
 const handleModalOption = async (option) => {
     console.debug('Modal option selected:', option);
     const cb = modalCallback;
-    const hasCallback = Boolean(cb);
+    const hasCallback = typeof cb === 'function';
     console.debug('Has modal callback:', hasCallback);
     closeModal();
     if (hasCallback) {


### PR DESCRIPTION
## Summary
- ensure callbacks in the deletion modal are functions before invoking

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686dd3fbdb048324b2de6d8ad6186712