### PR TITLE
Fix modal callback registration

### DIFF
--- a/src/components/TracksideWidget.js
+++ b/src/components/TracksideWidget.js
@@ -140,7 +140,7 @@ const TracksideWidget = () => {
 
   const handleDeleteEvent = async ({ props }) => {
     setIsModalOpen(true);
-    setModalCallback(async (confirm) => {
+    setModalCallback(() => async (confirm) => {
       if (confirm) {
         try {
           console.debug('Deleting event with id:', props.item.id);

--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -332,7 +332,7 @@ const Trackside = () => {
   const handleDeleteEvent = async ({ props }) => {
     setModalMessage('Are you sure you want to delete this event? This action cannot be undone and will remove all associated sessions and data.');
     setIsModalOpen(true);
-    setModalCallback(async (confirm) => {
+    setModalCallback(() => async (confirm) => {
       if (confirm) {
         try {
           console.debug('Deleting event with id:', props.item.id);
@@ -479,7 +479,7 @@ const handleModalOption = async (option) => {
   const handleDeleteSession = async ({ props }) => {
     setModalMessage('Are you sure you want to delete this session? This action cannot be undone and will remove all associated data.');
     setIsModalOpen(true);
-    setModalCallback(async (confirm) => {
+    setModalCallback(() => async (confirm) => {
       if (confirm) {
         try {
           if (currentSession === props.session.id) {


### PR DESCRIPTION
## Summary
- ensure delete confirmation modals store callbacks correctly
- same fix for Trackside Widget

## Testing
- `npm run build-main`
- `npm run build-renderer`


------
https://chatgpt.com/codex/tasks/task_e_686dd7256fa48324be0fae0ce44c425c