### PR TITLE
Add automatic loading overlay

### DIFF
--- a/src/components/LoadingOverlay.css
+++ b/src/components/LoadingOverlay.css
@@ -9,6 +9,12 @@
   align-items: center;
   justify-content: center;
   z-index: 9999;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+}
+.loading-overlay.show {
+  opacity: 1;
 }
 .loading-icon {
   width: 100px;

--- a/src/components/LoadingOverlay.css
+++ b/src/components/LoadingOverlay.css
@@ -1,0 +1,16 @@
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 255, 0.4); /* slightly transparent blue */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+.loading-icon {
+  width: 100px;
+  height: 100px;
+}

--- a/src/components/LoadingOverlay.js
+++ b/src/components/LoadingOverlay.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useLoading } from '../context/LoadingContext';
+import './LoadingOverlay.css';
+
+const flagIcon =
+  'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODAiIGhlaWdodD0iNjQiIHZpZXdCb3g9IjAgMCA0MCAzMiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cmVjdCB4PSIyIiB5PSIyIiB3aWR0aD0iMiIgaGVpZ2h0PSIyOCIgZmlsbD0id2hpdGUiIC8+CiAgPGcgZmlsbD0id2hpdGUiPgogICAgPHJlY3QgeD0iNiIgeT0iMiIgd2lkdGg9IjYiIGhlaWdodD0iNiIvPgogICAgPHJlY3QgeD0iMTgiIHk9IjIiIHdpZHRoPSI2IiBoZWlnaHQ9IjYiLz4KICAgIDxyZWN0IHg9IjEyIiB5PSI4IiB3aWR0aD0iNiIgaGVpZ2h0PSI2Ii8+CiAgICA8cmVjdCB4PSIyNCIgeT0iOCIgd2lkdGg9IjYiIGhlaWdodD0iNiIvPgogICAgPHJlY3QgeD0iNiIgeT0iMTQiIHdpZHRoPSI2IiBoZWlnaHQ9IjYiLz4KICAgIDxyZWN0IHg9IjE4IiB5PSIxNCIgd2lkdGg9IjYiIGhlaWdodD0iNiIvPgogICAgPHJlY3QgeD0iMTIiIHk9IjIwIiB3aWR0aD0iNiIgaGVpZ2h0PSI2Ii8+CiAgICA8cmVjdCB4PSIyNCIgeT0iMjAiIHdpZHRoPSI2IiBoZWlnaHQ9IjYiLz4KICA8L2c+Cjwvc3ZnPgo=';
+
+const LoadingOverlay = () => {
+  const { isLoading } = useLoading();
+
+  if (!isLoading) return null;
+
+  return (
+    <div className="loading-overlay">
+      <img src={flagIcon} alt="loading" className="loading-icon" />
+    </div>
+  );
+};
+
+export default LoadingOverlay;

--- a/src/components/LoadingOverlay.js
+++ b/src/components/LoadingOverlay.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useLoading } from '../context/LoadingContext';
 import './LoadingOverlay.css';
 
@@ -7,11 +7,21 @@ const flagIcon =
 
 const LoadingOverlay = () => {
   const { isLoading } = useLoading();
+  const [visible, setVisible] = useState(false);
 
-  if (!isLoading) return null;
+  useEffect(() => {
+    if (isLoading) {
+      setVisible(true);
+    } else {
+      const timer = setTimeout(() => setVisible(false), 200);
+      return () => clearTimeout(timer);
+    }
+  }, [isLoading]);
+
+  if (!visible) return null;
 
   return (
-    <div className="loading-overlay">
+    <div className={`loading-overlay ${isLoading ? 'show' : ''}`}> 
       <img src={flagIcon} alt="loading" className="loading-icon" />
     </div>
   );

--- a/src/context/CarContext.js
+++ b/src/context/CarContext.js
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
+import { useLoading } from './LoadingContext';
 
 const CarContext = createContext();
 
@@ -9,6 +10,7 @@ export const useCar = () => {
 export const CarProvider = ({ children }) => {
   const [cars, setCars] = useState([]);
   const [selectedCar, setSelectedCar] = useState(localStorage.getItem('selectedCar') || '');
+  const { showLoading, hideLoading } = useLoading();
 
   useEffect(() => {
     loadCars();
@@ -21,13 +23,17 @@ export const CarProvider = ({ children }) => {
   }, [selectedCar]);
 
   const loadCars = async () => {
-    const fetchedCars = await window.api.getCars();
-    setCars(fetchedCars);
+    showLoading();
+    try {
+      const fetchedCars = await window.api.getCars();
+      setCars(fetchedCars);
 
-    // Set default car if none is selected
-    if (!selectedCar && fetchedCars.length > 0) {
-      setSelectedCar(fetchedCars[0].id);
-      localStorage.setItem('selectedCar', fetchedCars[0].id);
+      if (!selectedCar && fetchedCars.length > 0) {
+        setSelectedCar(fetchedCars[0].id);
+        localStorage.setItem('selectedCar', fetchedCars[0].id);
+      }
+    } finally {
+      hideLoading();
     }
   };
 

--- a/src/context/LoadingContext.js
+++ b/src/context/LoadingContext.js
@@ -1,0 +1,18 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const LoadingContext = createContext();
+
+export const LoadingProvider = ({ children }) => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const showLoading = () => setIsLoading(true);
+  const hideLoading = () => setIsLoading(false);
+
+  return (
+    <LoadingContext.Provider value={{ isLoading, showLoading, hideLoading }}>
+      {children}
+    </LoadingContext.Provider>
+  );
+};
+
+export const useLoading = () => useContext(LoadingContext);

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import './Home.css';
 import { useNavigate } from 'react-router-dom';
 import { useCar } from '../context/CarContext';
+import { useLoading } from '../context/LoadingContext';
 import TracksideWidget from '../components/TracksideWidget';
 import StatsWidget from '../components/StatsWidget';
 
@@ -10,6 +11,7 @@ const Home = () => {
   const [parts, setParts] = useState([]);
   const fileInputRef = useRef(null);
   const navigate = useNavigate();
+  const { showLoading, hideLoading } = useLoading();
 
   useEffect(() => {
     loadCars();
@@ -17,9 +19,13 @@ const Home = () => {
 
   useEffect(() => {
     if (selectedCar) {
-      window.api.getParts(selectedCar).then((fetchedParts) => {
-        setParts(fetchedParts);
-      });
+      showLoading();
+      window.api
+        .getParts(selectedCar)
+        .then((fetchedParts) => {
+          setParts(fetchedParts);
+        })
+        .finally(() => hideLoading());
     } else {
       setParts([]);
     }
@@ -57,11 +63,14 @@ const Home = () => {
 
   const handleExportCar = async () => {
     if (!selectedCar) return;
+    showLoading();
     try {
       const filePath = await window.api.exportCarData(selectedCar);
       alert(`Car exported to ${filePath}`);
     } catch (error) {
       console.error('Error exporting car:', error);
+    } finally {
+      hideLoading();
     }
   };
 
@@ -72,12 +81,15 @@ const Home = () => {
   const handleFileChange = async (e) => {
     const file = e.target.files[0];
     if (file) {
+      showLoading();
       try {
         await window.api.importCarData(file.path);
         loadCars();
         alert('Car imported successfully');
       } catch (error) {
         console.error('Error importing car:', error);
+      } finally {
+        hideLoading();
       }
     }
   };

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -4,12 +4,17 @@ import { createRoot } from 'react-dom/client';
 import { HashRouter as Router, Route, Switch } from 'react-router-dom';
 import App from './App';
 import './index.css';
+import { LoadingProvider } from './context/LoadingContext';
+import LoadingOverlay from './components/LoadingOverlay';
 
 const container = document.getElementById('root');
 const root = createRoot(container);
 
 root.render(
   <Router>
-    <App />
+    <LoadingProvider>
+      <App />
+      <LoadingOverlay />
+    </LoadingProvider>
   </Router>
 );


### PR DESCRIPTION
## Summary
- add LoadingOverlay component with CSS
- add LoadingProvider context and use in CarContext and Home page
- show blue fullscreen loader on async operations
- wrap app with LoadingProvider in renderer

## Testing
- `npm run build-main` *(fails: webpack not found)*
- `npx webpack --config webpack.main.config.js` *(fails: requires installing packages)*

------
https://chatgpt.com/codex/tasks/task_e_686e85c570188324824df59a75371bc6