### PR TITLE
Improve rename overlays

### DIFF
--- a/src/pages/Garage.css
+++ b/src/pages/Garage.css
@@ -224,6 +224,12 @@ button:hover {
   margin: 0;
   box-sizing: border-box;
 }
+
+.editing-input.inline {
+  display: inline-block;
+  width: auto;
+  min-width: 1ch;
+}
 .search-controls {
   display: flex;
   align-items: center;

--- a/src/pages/Garage.js
+++ b/src/pages/Garage.js
@@ -277,6 +277,13 @@ const Garage = () => {
 
   const handleTitleContextMenu = (e) => {
     e.preventDefault();
+    contextMenu.show({
+      id: 'title-menu',
+      event: e.nativeEvent || e
+    });
+  };
+
+  const startRenameTitle = () => {
     setEditingTitle(true);
     setEditingName(sessionTitle);
   };
@@ -386,26 +393,26 @@ const Garage = () => {
         {events.length > 0 ? (
           events.map((event, index) => (
             <div key={index} className="event-group">
-              {editingEventId === event.id ? (
-                <input
-                  type="text"
-                  value={editingName}
-                  onChange={handleEditingNameChange}
-                  onBlur={handleEditingNameBlur}
-                  autoFocus
-                  className="editing-input"
-                />
-              ) : (
-                <button
-                  className={`accordion-button ${selectedEventId === event.id ? 'expanded' : ''}`}
-                  onClick={() => handleEventClick(event.id)}
-                  onContextMenu={(e) => handleContextMenu(e, event, 'event')}
-                  onDragOver={(e) => { e.preventDefault(); handleEventDragOver(event.id); }}
-                  onDrop={() => handleSessionDrop(event.id, event.Sessions.length)}
-                >
-                  {event.name}
-                </button>
-              )}
+              <button
+                className={`accordion-button ${selectedEventId === event.id ? 'expanded' : ''}`}
+                onClick={() => handleEventClick(event.id)}
+                onContextMenu={(e) => handleContextMenu(e, event, 'event')}
+                onDragOver={(e) => { e.preventDefault(); handleEventDragOver(event.id); }}
+                onDrop={() => handleSessionDrop(event.id, event.Sessions.length)}
+              >
+                {editingEventId === event.id ? (
+                  <input
+                    type="text"
+                    value={editingName}
+                    onChange={handleEditingNameChange}
+                    onBlur={handleEditingNameBlur}
+                    autoFocus
+                    className="editing-input inline"
+                  />
+                ) : (
+                  event.name
+                )}
+              </button>
               {selectedEventId === event.id && (
                 <ul
                   onDragOver={(e) => { e.preventDefault(); handleEventDragOver(event.id); }}
@@ -422,24 +429,24 @@ const Garage = () => {
                         onDrop={() => handleSessionDrop(event.id, index)}
                         onContextMenu={(e) => handleContextMenu(e, session, 'session')}
                       >
-                        {editingSessionId === session.id ? (
-                          <input
-                            type="text"
-                            value={editingName}
-                            onChange={handleEditingNameChange}
-                            onBlur={handleEditingNameBlur}
-                            autoFocus
-                            className="editing-input"
-                          />
+                        <span>
+                          {editingSessionId === session.id ? (
+                            <input
+                              type="text"
+                              value={editingName}
+                              onChange={handleEditingNameChange}
+                              onBlur={handleEditingNameBlur}
+                              autoFocus
+                              className="editing-input inline"
+                            />
+                          ) : (
+                            session.name
+                          )}
+                        </span>
+                        {currentSessionId === session.id ? (
+                          <button className="load-btn" disabled>Loaded</button>
                         ) : (
-                          <>
-                            <span>{session.name}</span>
-                            {currentSessionId === session.id ? (
-                              <button className="load-btn" disabled>Loaded</button>
-                            ) : (
-                              <button className="load-btn" onClick={() => handleLoadSession(session)}>Load</button>
-                            )}
-                          </>
+                          <button className="load-btn" onClick={() => handleLoadSession(session)}>Load</button>
                         )}
                       </li>
                     ))
@@ -553,6 +560,9 @@ const Garage = () => {
       <Menu id="session-menu">
         <Item onClick={handleRenameSession}>Rename Session</Item>
         <Item onClick={handleDeleteSession}>Delete Session</Item>
+      </Menu>
+      <Menu id="title-menu">
+        <Item onClick={startRenameTitle}>Rename Title</Item>
       </Menu>
     </div>
   );

--- a/src/pages/Trackside.css
+++ b/src/pages/Trackside.css
@@ -269,9 +269,16 @@ li {
 }
 
 .session-tab input {
-  width: 100%;
+  width: auto;
+  min-width: 1ch;
   border: none;
   background: transparent;
+  color: inherit;
+}
+
+.session-tab.active input {
+  color: #fff;
+  border-bottom: 1px solid #fff;
 }
 
 .session-tab.active {

--- a/src/pages/Trackside.js
+++ b/src/pages/Trackside.js
@@ -744,6 +744,7 @@ const handleModalOption = async (option) => {
                       onBlur={saveSessionName}
                       onKeyDown={(e) => { if (e.key === 'Enter') saveSessionName(); }}
                       autoFocus
+                      style={{ width: `${Math.max(editingSessionName.length, 1)}ch` }}
                     />
                   ) : (
                     session.name || session


### PR DESCRIPTION
## Summary
- keep garage accordion button visible while renaming
- keep load button visible during session rename
- add context menu for renaming the garage title
- refine inline input styles and allow dynamic width on trackside tabs
- ensure active tab rename uses white underline

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686fd1625a608324a51acfd06884dd23