### PR TITLE
Improve car creation flow

### DIFF
--- a/src/pages/CreateCar.js
+++ b/src/pages/CreateCar.js
@@ -1,13 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useCar } from '../context/CarContext';
+import './CreateCar.css';
 
 const CreateCar = () => {
   const [name, setName] = useState('');
   const [templateId, setTemplateId] = useState('');
   const [templates, setTemplates] = useState([]);
   const navigate = useNavigate();
-  const { loadCars } = useCar(); // Get loadCars from context
+  const { loadCars, setSelectedCar } = useCar();
 
   useEffect(() => {
     const fetchTemplates = async () => {
@@ -23,7 +24,8 @@ const CreateCar = () => {
         await window.api.applyTemplateToCar(templateId, car.id);
       }
       loadCars();
-      navigate('/');
+      setSelectedCar(car.id);
+      navigate('/manage-parts', { state: { carId: car.id, carName: car.name } });
     });
   };
 

--- a/src/pages/ManageParts.js
+++ b/src/pages/ManageParts.js
@@ -284,7 +284,7 @@ const ManageParts = () => {
             </div>
           ))}
         </div>
-        <button className="save-notes" onClick={handleSave}>Save Parts</button>
+        <button className="save-notes" onClick={handleSave}>Save Car</button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- import CreateCar.css so styles match other pages
- set new car as active and go to manage parts after creation
- rename save button to "Save Car" in ManageParts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686fd8876fb0832487a7524ebb76ca45